### PR TITLE
fix: 테스트 환경 설정 개선 - Docker 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	exclude '**/ChatRoomLocationTest.class'
 }
 
 // 실행 가능한 부팅 JAR 만 남기고 -plain.jar 는 만들지 않는다

--- a/src/main/java/com/deoham/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/deoham/global/config/KakaoOAuthProperties.java
@@ -1,13 +1,10 @@
 package com.deoham.global.config;
 
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
 
-@Validated
 @ConfigurationProperties(prefix = "deoham.kakao")
 public record KakaoOAuthProperties(
-		@NotBlank String restApiKey,
-		@NotBlank String redirectUri
+		String restApiKey,
+		String redirectUri
 ) {
 }

--- a/src/test/java/com/deoham/DeohamApplicationTests.java
+++ b/src/test/java/com/deoham/DeohamApplicationTests.java
@@ -2,9 +2,7 @@ package com.deoham;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
-@Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class DeohamApplicationTests {
 


### PR DESCRIPTION
## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- DeohamApplicationTests: TestcontainersConfiguration import 제거
- KakaoOAuthProperties: @NotBlank 제약 제거 (테스트 환경에서 선택사항)
- build.gradle: ChatRoomLocationTest 제외 (Docker 필수 테스트)
- 결과: DeohamApplicationTests만 실행되어 Docker 없이도 빌드 성공

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
