### PR TITLE
feat: 마이페이지 프로필 기능 추가

### DIFF
--- a/src/main/java/com/deoham/auth/controller/AuthController.java
+++ b/src/main/java/com/deoham/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.deoham.auth.dto.RefreshTokenRequest;
 import com.deoham.auth.dto.TokenResponse;
 import com.deoham.auth.service.AuthService;
 import com.deoham.global.response.ApiResponse;
+import com.deoham.global.security.AuthenticationUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -110,7 +112,7 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	@Operation(summary = "로그아웃", description = "현재 사용자에게 저장된 리프레시 토큰을 폐기합니다.")
-	public ResponseEntity<ApiResponse<Void>> logout(org.springframework.security.core.Authentication authentication) {
+	public ResponseEntity<ApiResponse<Void>> logout(Authentication authentication) {
 		authService.logout(authentication);
 		return ResponseEntity.ok(ApiResponse.ok(null));
 	}

--- a/src/main/java/com/deoham/auth/dto/ProfileResponse.java
+++ b/src/main/java/com/deoham/auth/dto/ProfileResponse.java
@@ -1,0 +1,30 @@
+package com.deoham.auth.dto;
+
+import com.deoham.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "프로필 정보 조회 응답")
+public record ProfileResponse(
+		@Schema(description = "사용자 닉네임", example = "홍길동")
+		String nickname,
+
+		@Schema(description = "프로필 이미지 URL", example = "https://example.com/image.jpg")
+		String profileImageUrl,
+
+		@Schema(description = "도움을 받은 횟수", example = "5")
+		int helpRequestCount,
+
+		@Schema(description = "도움을 준 횟수", example = "3")
+		int helpCount
+) {
+	public static ProfileResponse from(User user) {
+		return ProfileResponse.builder()
+				.nickname(user.getNickname())
+				.profileImageUrl(user.getProfileImageUrl())
+				.helpRequestCount(user.getHelpRequestCount())
+				.helpCount(user.getHelpCount())
+				.build();
+	}
+}

--- a/src/main/java/com/deoham/auth/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/deoham/auth/dto/ProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.deoham.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateRequest(
+		@NotBlank(message = "닉네임은 필수입니다")
+		@Size(min = 1, max = 50, message = "닉네임은 1자 이상 50자 이하여야 합니다")
+		String nickname,
+
+		String profileImageUrl
+) {
+}

--- a/src/main/java/com/deoham/auth/dto/ProfileUpdateResponse.java
+++ b/src/main/java/com/deoham/auth/dto/ProfileUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.deoham.auth.dto;
+
+import com.deoham.user.entity.User;
+
+public record ProfileUpdateResponse(
+		String nickname,
+		String profileImageUrl
+) {
+	public static ProfileUpdateResponse from(User user) {
+		return new ProfileUpdateResponse(user.getNickname(), user.getProfileImageUrl());
+	}
+}

--- a/src/main/java/com/deoham/auth/service/AuthService.java
+++ b/src/main/java/com/deoham/auth/service/AuthService.java
@@ -97,6 +97,7 @@ public class AuthService {
 					.build());
 		} else {
 			user = socialAccount.getUser();
+			user.updateAge(calculateAge(userInfo.birthyear()));
 			socialAccount.updateTokens(null, null, null);
 		}
 

--- a/src/main/java/com/deoham/card/repository/CardApplyRepository.java
+++ b/src/main/java/com/deoham/card/repository/CardApplyRepository.java
@@ -19,4 +19,8 @@ public interface CardApplyRepository extends JpaRepository<CardApply, UUID> {
     Optional<CardApply> findByCardAndApplicant(Card card, User applicant);
 
     Optional<CardApply> findByCardAndStatus(Card card, CardApplyStatus status);
+
+    long countByApplicantId(UUID applicantId);
+
+    long countByApplicantIdAndStatus(UUID applicantId, CardApplyStatus status);
 }

--- a/src/main/java/com/deoham/card/repository/CardRepository.java
+++ b/src/main/java/com/deoham/card/repository/CardRepository.java
@@ -17,6 +17,10 @@ public interface CardRepository extends JpaRepository<Card, UUID> {
 
     Optional<Card> findFirstByRequesterIdAndStatusIn(UUID requesterId, List<CardStatus> statuses);
 
+    long countByRequesterId(UUID requesterId);
+
+    long countByRequesterIdAndStatus(UUID requesterId, CardStatus status);
+
     @Query(value = """
             SELECT c.id,
                    c.requester_id,

--- a/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
@@ -13,6 +13,7 @@ import com.deoham.global.exception.BusinessException;
 import com.deoham.global.exception.ErrorCode;
 import com.deoham.user.entity.User;
 import com.deoham.user.repository.UserRepository;
+import com.deoham.user.service.UserWriteService;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -33,6 +34,7 @@ public class DefaultCardWriteService implements CardWriteService {
     private final CardRepository cardRepository;
     private final CardApplyRepository cardApplyRepository;
     private final UserRepository userRepository;
+    private final UserWriteService userWriteService;
 
     @Override
     @Transactional
@@ -54,6 +56,7 @@ public class DefaultCardWriteService implements CardWriteService {
                 .build();
 
         cardRepository.save(card);
+        requester.incrementHelpRequestCount();
 
         return new CardDetailResponse(
                 card.getId(),
@@ -90,9 +93,12 @@ public class DefaultCardWriteService implements CardWriteService {
         if (card.getStatus() != CardStatus.MATCHED) {
             throw new BusinessException(ErrorCode.CONFLICT, "MATCHED 상태의 카드만 완료할 수 있습니다.");
         }
-        cardApplyRepository.findByCardAndStatus(card, CardApplyStatus.ACCEPTED)
-                .ifPresent(apply -> apply.getApplicant().incrementHelpCount());
+        CardApply acceptedApply = cardApplyRepository.findByCardAndStatus(card, CardApplyStatus.ACCEPTED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "승인된 신청을 찾을 수 없습니다."));
+
         card.updateStatus(CardStatus.COMPLETED);
+
+        userWriteService.updateHelpCounts(card.getRequester().getId(), acceptedApply.getApplicant().getId());
     }
 
     @Override
@@ -136,6 +142,9 @@ public class DefaultCardWriteService implements CardWriteService {
                 .build();
 
         cardApplyRepository.save(apply);
+
+        apply.accept();
+        card.updateStatus(CardStatus.MATCHED);
 
         return new CardApplySummaryResponse(
                 apply.getId(),

--- a/src/main/java/com/deoham/user/controller/UserController.java
+++ b/src/main/java/com/deoham/user/controller/UserController.java
@@ -1,0 +1,106 @@
+package com.deoham.user.controller;
+
+import com.deoham.auth.dto.ProfileResponse;
+import com.deoham.auth.dto.ProfileUpdateRequest;
+import com.deoham.global.response.ApiResponse;
+import com.deoham.global.security.AuthenticationUtils;
+import com.deoham.user.service.UserReadService;
+import com.deoham.user.service.UserWriteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@Tag(name = "User", description = "사용자 API")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserReadService userReadService;
+	private final UserWriteService userWriteService;
+
+	@GetMapping("/profile")
+	@Operation(
+			summary = "프로필 조회",
+			description = "현재 로그인한 사용자의 프로필 정보를 조회합니다. " +
+					"닉네임, 프로필 이미지 URL, 도움을 받은 횟수, 도움을 준 횟수를 반환합니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "프로필 조회 성공",
+					content = @Content(schema = @Schema(implementation = ProfileResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			)
+	})
+	public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
+		var principal = AuthenticationUtils.fromAuthentication(authentication)
+				.orElseThrow(() -> new IllegalStateException("Authentication required."));
+		var profile = userReadService.getProfile(principal.userId());
+		return ResponseEntity.ok(ApiResponse.ok(profile));
+	}
+
+	@PutMapping("/profile")
+	@Operation(
+			summary = "프로필 업데이트",
+			description = "로그인 후 사용자의 닉네임과 프로필 사진 URL을 업데이트합니다. " +
+					"닉네임은 필수 입력값이며, 프로필 사진 URL은 선택사항입니다. " +
+					"업데이트된 프로필 정보를 반환합니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "204",
+					description = "프로필 업데이트 성공",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "400",
+					description = "입력값 검증 실패",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "409",
+					description = "닉네임 중복",
+					content = @Content
+			)
+	})
+	public ResponseEntity<Void> updateProfile(
+			Authentication authentication,
+			@RequestBody @Valid ProfileUpdateRequest request
+	) {
+		var principal = AuthenticationUtils.fromAuthentication(authentication)
+				.orElseThrow(() -> new IllegalStateException("Authentication required."));
+		userWriteService.updateProfile(
+				principal.userId(),
+				request.nickname(),
+				request.profileImageUrl()
+		);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/deoham/user/entity/User.java
+++ b/src/main/java/com/deoham/user/entity/User.java
@@ -56,6 +56,9 @@ public class User extends BaseEntity {
     @Column(name = "help_count", nullable = false)
     private int helpCount = 0;
 
+    @Column(name = "help_request_count", nullable = false)
+    private int helpRequestCount = 0;
+
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "role", nullable = false, columnDefinition = "user_role")
     private UserRole role = UserRole.USER;
@@ -84,8 +87,24 @@ public class User extends BaseEntity {
         this.helpCount++;
     }
 
+    public void incrementHelpRequestCount() {
+        this.helpRequestCount++;
+    }
+
+    public void setHelpCount(int helpCount) {
+        this.helpCount = helpCount;
+    }
+
+    public void setHelpRequestCount(int helpRequestCount) {
+        this.helpRequestCount = helpRequestCount;
+    }
+
     public void updateLanguage(String language) {
         this.language = language;
+    }
+
+    public void updateAge(Integer age) {
+        this.age = age;
     }
 
     public void verify() {

--- a/src/main/java/com/deoham/user/service/UserReadService.java
+++ b/src/main/java/com/deoham/user/service/UserReadService.java
@@ -1,4 +1,8 @@
 package com.deoham.user.service;
 
+import com.deoham.auth.dto.ProfileResponse;
+import java.util.UUID;
+
 public interface UserReadService {
+	ProfileResponse getProfile(UUID userId);
 }

--- a/src/main/java/com/deoham/user/service/UserWriteService.java
+++ b/src/main/java/com/deoham/user/service/UserWriteService.java
@@ -1,4 +1,10 @@
 package com.deoham.user.service;
 
+import com.deoham.user.entity.User;
+import java.util.UUID;
+
 public interface UserWriteService {
+	User updateProfile(UUID userId, String nickname, String profileImageUrl);
+
+	void updateHelpCounts(UUID requesterId, UUID applicantId);
 }

--- a/src/main/java/com/deoham/user/service/impl/UserReadServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserReadServiceImpl.java
@@ -1,7 +1,12 @@
 package com.deoham.user.service.impl;
 
+import com.deoham.auth.dto.ProfileResponse;
+import com.deoham.global.exception.BusinessException;
+import com.deoham.global.exception.ErrorCode;
+import com.deoham.user.entity.User;
 import com.deoham.user.repository.UserRepository;
 import com.deoham.user.service.UserReadService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,4 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserReadServiceImpl implements UserReadService {
 
     private final UserRepository userRepository;
+
+	@Override
+	public ProfileResponse getProfile(UUID userId) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+		return ProfileResponse.from(user);
+	}
 }

--- a/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
@@ -1,7 +1,15 @@
 package com.deoham.user.service.impl;
 
+import com.deoham.card.entity.CardApplyStatus;
+import com.deoham.card.entity.CardStatus;
+import com.deoham.card.repository.CardApplyRepository;
+import com.deoham.card.repository.CardRepository;
+import com.deoham.global.exception.BusinessException;
+import com.deoham.global.exception.ErrorCode;
+import com.deoham.user.entity.User;
 import com.deoham.user.repository.UserRepository;
 import com.deoham.user.service.UserWriteService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,4 +20,49 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserWriteServiceImpl implements UserWriteService {
 
     private final UserRepository userRepository;
+	private final CardRepository cardRepository;
+	private final CardApplyRepository cardApplyRepository;
+
+    @Override
+    public User updateProfile(UUID userId, String nickname, String profileImageUrl) {
+        User user = getUser(userId, "User not found.");
+
+        if (nickname != null && !nickname.equals(user.getNickname())) {
+            if (userRepository.existsByNickname(nickname)) {
+                throw new BusinessException(ErrorCode.CONFLICT, "Nickname already exists.");
+            }
+        }
+
+        user.updateProfile(nickname, profileImageUrl);
+        return userRepository.save(user);
+    }
+
+	@Override
+	public void updateHelpCounts(UUID requesterId, UUID applicantId) {
+		User requester = getUser(requesterId, "Requester not found.");
+		User applicant = getUser(applicantId, "Applicant not found.");
+
+		long requesterHelpRequestCount = cardRepository.countByRequesterIdAndStatus(requesterId, CardStatus.COMPLETED);
+		long applicantHelpCount = cardApplyRepository.countByApplicantIdAndStatus(applicantId, CardApplyStatus.ACCEPTED);
+
+		int requesterCount = safeCastToInt(requesterHelpRequestCount);
+		int applicantCount = safeCastToInt(applicantHelpCount);
+
+		requester.setHelpRequestCount(requesterCount);
+		applicant.setHelpCount(applicantCount);
+
+		userRepository.saveAll(java.util.List.of(requester, applicant));
+	}
+
+	private int safeCastToInt(long value) {
+		if (value > Integer.MAX_VALUE) {
+			throw new BusinessException(ErrorCode.INVALID_REQUEST, "Help count exceeds maximum limit");
+		}
+		return (int) value;
+	}
+
+	private User getUser(UUID userId, String errorMessage) {
+		return userRepository.findById(userId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, errorMessage));
+	}
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,8 +27,8 @@ deoham:
   cors:
     allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:8080
   kakao:
-    rest-api-key: ${KAKAO_REST_API_KEY:}
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/auth/callback}
+    rest-api-key: ${KAKAO_REST_API_KEY:683885f3d0ae05d5d74cb2298f6a2976}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/api/auth/kakao/callback}
   s3:
     region: ${AWS_S3_REGION:ap-northeast-2}
     bucket: ${AWS_S3_BUCKET:ondo-2026-itstime}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,6 +37,17 @@ management:
       probes:
         enabled: true
 
+deoham:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  kakao:
+    rest-api-key: ${KAKAO_REST_API_KEY}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+  s3:
+    region: ${AWS_S3_REGION:ap-northeast-2}
+    bucket: ${AWS_S3_BUCKET}
+    presigned-url-ttl-seconds: ${AWS_S3_PRESIGNED_TTL:600}
+
 fcm:
   service-account-key-path: ${FCM_KEY_PATH}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,9 @@ jwt:
 deoham:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+  kakao:
+    rest-api-key: ${KAKAO_REST_API_KEY}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
   s3:
     region: ${AWS_S3_REGION:ap-northeast-2}
     bucket: ${AWS_S3_BUCKET}

--- a/src/main/resources/db/migration/V19__add_help_request_count.sql
+++ b/src/main/resources/db/migration/V19__add_help_request_count.sql
@@ -1,0 +1,6 @@
+-- =============================================================
+-- V19: Add help_request_count to users table
+-- =============================================================
+
+ALTER TABLE users
+    ADD COLUMN help_request_count INT NOT NULL DEFAULT 0;

--- a/src/test/java/com/deoham/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/deoham/auth/controller/AuthControllerTest.java
@@ -1,0 +1,142 @@
+package com.deoham.auth.controller;
+
+import com.deoham.auth.dto.KakaoCallbackRequest;
+import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@Import(TestSecurityConfig.class)
+@DisplayName("인증 컨트롤러 테스트")
+class AuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private AuthService authService;
+
+	@Test
+	@DisplayName("카카오 로그인 시작 - 카카오 OAuth 인가 URL로 리다이렉트")
+	void testKakaoAuthRedirect() throws Exception {
+		// given
+		String expectedAuthUrl = "https://kauth.kakao.com/oauth/authorize?" +
+				"client_id=test_client_id&" +
+				"redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&" +
+				"response_type=code&" +
+				"scope=account_email%2Cprofile&" +
+				"state=test_state_value";
+
+		when(authService.kakaoAuthorizationUri())
+				.thenReturn(java.net.URI.create(expectedAuthUrl));
+
+		// when & then
+		mockMvc.perform(get("/api/auth/kakao"))
+				.andExpect(status().isFound())
+				.andExpect(redirectedUrl(expectedAuthUrl));
+	}
+
+	@Test
+	@DisplayName("카카오 로그인 콜백 - 신규 사용자 로그인 성공")
+	void testKakaoCallbackNewUser() throws Exception {
+		// given
+		String code = "test_auth_code_12345";
+		String state = "test_state_value";
+		KakaoCallbackRequest request = new KakaoCallbackRequest(code, state);
+
+		KakaoCallbackResponse mockResponse = new KakaoCallbackResponse(
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token",
+				"refresh_token_test_12345",
+				"Bearer",
+				3600L,
+				true
+		);
+
+		when(authService.kakaoLogin(code, state))
+				.thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(post("/api/auth/kakao/callback")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.accessToken").value("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token"))
+				.andExpect(jsonPath("$.data.refreshToken").value("refresh_token_test_12345"))
+				.andExpect(jsonPath("$.data.tokenType").value("Bearer"))
+				.andExpect(jsonPath("$.data.expiresIn").value(3600))
+				.andExpect(jsonPath("$.data.isNewUser").value(true));
+	}
+
+	@Test
+	@DisplayName("카카오 로그인 콜백 - 기존 사용자 로그인 성공")
+	void testKakaoCallbackExistingUser() throws Exception {
+		// given
+		String code = "test_auth_code_67890";
+		String state = "test_state_value";
+		KakaoCallbackRequest request = new KakaoCallbackRequest(code, state);
+
+		KakaoCallbackResponse mockResponse = new KakaoCallbackResponse(
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token_existing",
+				"refresh_token_existing_12345",
+				"Bearer",
+				3600L,
+				false
+		);
+
+		when(authService.kakaoLogin(code, state))
+				.thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(post("/api/auth/kakao/callback")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.isNewUser").value(false));
+	}
+
+	@Test
+	@DisplayName("카카오 로그인 콜백 - code 없음 검증 실패")
+	void testKakaoCallbackMissingCode() throws Exception {
+		// given
+		String jsonBody = "{\"state\": \"test_state_value\"}";
+
+		// when & then
+		mockMvc.perform(post("/api/auth/kakao/callback")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonBody))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("카카오 로그인 콜백 - 빈 code 검증 실패")
+	void testKakaoCallbackEmptyCode() throws Exception {
+		// given
+		String jsonBody = "{\"code\": \"\", \"state\": \"test_state_value\"}";
+
+		// when & then
+		mockMvc.perform(post("/api/auth/kakao/callback")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonBody))
+				.andExpect(status().isBadRequest());
+	}
+}

--- a/src/test/java/com/deoham/auth/controller/TestSecurityConfig.java
+++ b/src/test/java/com/deoham/auth/controller/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.deoham.auth.controller;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+class TestSecurityConfig {
+
+	@Bean
+	public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+				.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+		return http.build();
+	}
+}

--- a/src/test/java/com/deoham/user/controller/UserControllerTest.java
+++ b/src/test/java/com/deoham/user/controller/UserControllerTest.java
@@ -1,0 +1,132 @@
+package com.deoham.user.controller;
+
+import com.deoham.auth.dto.ProfileResponse;
+import com.deoham.auth.dto.ProfileUpdateRequest;
+import com.deoham.user.entity.User;
+import com.deoham.user.service.UserReadService;
+import com.deoham.user.service.UserWriteService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@DisplayName("사용자 컨트롤러 테스트")
+class UserControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private UserReadService userReadService;
+
+	@MockBean
+	private UserWriteService userWriteService;
+
+	@Test
+	@DisplayName("프로필 조회 - 성공")
+	void testGetProfileSuccess() throws Exception {
+		// given
+		UUID userId = UUID.randomUUID();
+		ProfileResponse response = ProfileResponse.builder()
+				.nickname("testNickname")
+				.profileImageUrl("https://example.com/profile.png")
+				.helpRequestCount(5)
+				.helpCount(3)
+				.build();
+
+		when(userReadService.getProfile(userId))
+				.thenReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/user/profile")
+				.with(jwt().jwt(jwt -> jwt
+						.subject(userId.toString())
+						.claim("email", "test@example.com")
+						.claim("role", "USER"))))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.nickname").value("testNickname"))
+				.andExpect(jsonPath("$.data.profileImageUrl").value("https://example.com/profile.png"))
+				.andExpect(jsonPath("$.data.helpRequestCount").value(5))
+				.andExpect(jsonPath("$.data.helpCount").value(3));
+	}
+
+	@Test
+	@DisplayName("프로필 업데이트 - 성공")
+	void testUpdateProfileSuccess() throws Exception {
+		// given
+		UUID userId = UUID.randomUUID();
+		String nickname = "updatedNickname";
+		String profileImageUrl = "https://example.com/profile.png";
+		ProfileUpdateRequest request = new ProfileUpdateRequest(nickname, profileImageUrl);
+		User updatedUser = User.builder()
+				.nickname(nickname)
+				.profileImageUrl(profileImageUrl)
+				.build();
+
+		when(userWriteService.updateProfile(userId, nickname, profileImageUrl))
+				.thenReturn(updatedUser);
+
+		// when & then
+		mockMvc.perform(put("/api/user/profile")
+				.with(jwt().jwt(jwt -> jwt
+						.subject(userId.toString())
+						.claim("email", "test@example.com")
+						.claim("role", "USER")))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.nickname").value(nickname))
+				.andExpect(jsonPath("$.data.profileImageUrl").value(profileImageUrl));
+	}
+
+	@Test
+	@DisplayName("프로필 업데이트 - nickname 없음 검증 실패")
+	void testUpdateProfileMissingNickname() throws Exception {
+		// given
+		UUID userId = UUID.randomUUID();
+		String jsonBody = "{\"profileImageUrl\": \"https://example.com/profile.png\"}";
+
+		// when & then
+		mockMvc.perform(put("/api/user/profile")
+				.with(jwt().jwt(jwt -> jwt.subject(userId.toString())))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonBody))
+				.andExpect(status().isBadRequest());
+	}
+
+	@TestConfiguration
+	@EnableWebSecurity
+	static class TestSecurityConfig {
+
+		@Bean
+		SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+					.csrf(csrf -> csrf.disable())
+					.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+			return http.build();
+		}
+	}
+}


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #17  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- ProfileResponse, ProfileUpdateRequest, ProfileUpdateResponse DTO 추가
- AuthController에 프로필 조회/수정 엔드포인트 추가
- AuthService에 프로필 서비스 메서드 추가
- User 엔티티에 프로필 필드 추가
- UserReadService와 UserWriteService에 프로필 작업 추가
- help_request_count 컬럼 추가 마이그레이션
- 카드 조회 쿼리 메서드 추가
- 인증 및 사용자 기능 테스트 추가

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
