### PR TITLE
fix: 배포 환경에 카카오 OAuth 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,11 @@ jobs:
           # CORS — 앱 프로젝트라 불필요, 필요 시 활성화
           # CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}
 
+          # Kakao OAuth
+          KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}
+          KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
+          KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
+
           # FCM — Java 바인딩 없음, 구현 완료 후 활성화
           # FCM_KEY_PATH=/app/secrets/fcm-service-account.json
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,8 +61,8 @@ deoham:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
   kakao:
-    rest-api-key: ${KAKAO_REST_API_KEY}
-    redirect-uri: ${KAKAO_REDIRECT_URI}
+    rest-api-key: ${KAKAO_REST_API_KEY:}
+    redirect-uri: ${KAKAO_REDIRECT_URI:}
   s3:
     region: ${AWS_S3_REGION:ap-northeast-2}
     bucket: ${AWS_S3_BUCKET}


### PR DESCRIPTION
배포 서버에서 GitHub secret으로 설정한 카카오 OAuth 자격증명이 제대로 전달됨

\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #3 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- GitHub Actions: .env 파일에 KAKAO_REST_API_KEY, KAKAO_REDIRECT_URI, KAKAO_CLIENT_SECRET 추가
- application.yml: kakao 설정 추가 (기본값은 빈 문자열)
- 프로파일별로 카카오 설정이 제대로 로드되도록 수정

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
