### PR TITLE
fix: 카카오 OAuth scope에서 profile 제거

### DIFF
--- a/src/main/java/com/deoham/auth/service/AuthService.java
+++ b/src/main/java/com/deoham/auth/service/AuthService.java
@@ -62,7 +62,7 @@ public class AuthService {
 				.queryParam("client_id", kakaoOAuthProperties.restApiKey())
 				.queryParam("redirect_uri", kakaoOAuthProperties.redirectUri())
 				.queryParam("response_type", "code")
-				.queryParam("scope", "account_email,profile")
+				.queryParam("scope", "account_email,gender,birthyear")
 				.queryParam("state", state)
 				.build()
 				.toUri();


### PR DESCRIPTION
## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- scope: account_email,profile → account_email,gender,birthyear
- 닉네임/프로필 이미지 동의 항목 불필요, 성별/생년도만 요청


## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
