### PR TITLE
fix: KAKAO_REDIRECT_URI를 secrets에서 vars로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
 
           # Kakao OAuth
           KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}
-          KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
+          KAKAO_REDIRECT_URI=${{ vars.KAKAO_REDIRECT_URI }}
           KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
 
           # FCM — Java 바인딩 없음, 구현 완료 후 활성화


### PR DESCRIPTION
## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
GitHub Variables에 저장된 KAKAO_REDIRECT_URI를 제대로 읽도록 수정
- secrets.KAKAO_REDIRECT_URI → vars.KAKAO_REDIRECT_URI

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
