### PR TITLE
feat: 회원 탈퇴(soft delete) 기능 및 Kakao OAuth client_secret 추가

### DIFF
--- a/src/main/java/com/deoham/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/deoham/auth/client/KakaoOAuthClient.java
@@ -3,12 +3,15 @@ package com.deoham.auth.client;
 import com.deoham.global.config.KakaoOAuthProperties;
 import com.deoham.global.exception.BusinessException;
 import com.deoham.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 
+@Slf4j
 @Component
 public class KakaoOAuthClient {
 
@@ -30,32 +33,33 @@ public class KakaoOAuthClient {
 		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
 		body.add("grant_type", "authorization_code");
 		body.add("client_id", props.restApiKey());
+		body.add("client_secret", props.clientSecret());
 		body.add("redirect_uri", props.redirectUri());
 		body.add("code", code);
 
-		return tokenClient.post()
-				.uri("/oauth/token")
-				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-				.body(body)
-				.retrieve()
-				.onStatus(
-						status -> status.is4xxClientError(),
-						(req, res) -> {
-							throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 인가 코드가 유효하지 않습니다.");
-						})
-				.body(KakaoTokenResponse.class);
+		try {
+			return tokenClient.post()
+					.uri("/oauth/token")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.body(body)
+					.retrieve()
+					.body(KakaoTokenResponse.class);
+		} catch (RestClientResponseException e) {
+			log.warn("Kakao token exchange failed. Status: {}, Response: {}", e.getStatusCode(), e.getResponseBodyAsString());
+			throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 인가 코드가 유효하지 않습니다. (redirect_uri 불일치, 코드 만료 또는 재사용)");
+		}
 	}
 
 	public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
-		return apiClient.get()
-				.uri("/v2/user/me")
-				.header("Authorization", "Bearer " + kakaoAccessToken)
-				.retrieve()
-				.onStatus(
-						status -> status.is4xxClientError(),
-						(req, res) -> {
-							throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다.");
-						})
-				.body(KakaoUserInfo.class);
+		try {
+			return apiClient.get()
+					.uri("/v2/user/me")
+					.header("Authorization", "Bearer " + kakaoAccessToken)
+					.retrieve()
+					.body(KakaoUserInfo.class);
+		} catch (RestClientResponseException e) {
+			log.warn("Kakao user info failed. Status: {}, Response: {}", e.getStatusCode(), e.getResponseBodyAsString());
+			throw new BusinessException(ErrorCode.UNAUTHORIZED, "카카오 사용자 정보 조회에 실패했습니다.");
+		}
 	}
 }

--- a/src/main/java/com/deoham/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/deoham/global/config/KakaoOAuthProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "deoham.kakao")
 public record KakaoOAuthProperties(
 		String restApiKey,
+		String clientSecret,
 		String redirectUri
 ) {
 }

--- a/src/main/java/com/deoham/user/controller/UserController.java
+++ b/src/main/java/com/deoham/user/controller/UserController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -101,6 +102,35 @@ public class UserController {
 				request.nickname(),
 				request.profileImageUrl()
 		);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping
+	@Operation(
+			summary = "회원 탈퇴",
+			description = "현재 로그인한 사용자의 계정을 탈퇴합니다. (soft delete)"
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "204",
+					description = "회원 탈퇴 성공",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			)
+	})
+	public ResponseEntity<Void> deleteUser(Authentication authentication) {
+		var principal = AuthenticationUtils.fromAuthentication(authentication)
+				.orElseThrow(() -> new IllegalStateException("Authentication required."));
+		userWriteService.deleteUser(principal.userId());
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/deoham/user/entity/User.java
+++ b/src/main/java/com/deoham/user/entity/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,11 +13,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
 import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
 @Table(name = "users")
+@Where(clause = "deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
@@ -66,6 +69,9 @@ public class User extends BaseEntity {
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "status", nullable = false, columnDefinition = "user_status")
     private UserStatus status = UserStatus.ACTIVE;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 
     @Builder
     private User(String firebaseUid, String nickname, String profileImageUrl, GenderType gender, Integer age) {
@@ -117,5 +123,6 @@ public class User extends BaseEntity {
 
     public void delete() {
         this.status = UserStatus.DELETED;
+        this.deletedAt = Instant.now();
     }
 }

--- a/src/main/java/com/deoham/user/service/UserWriteService.java
+++ b/src/main/java/com/deoham/user/service/UserWriteService.java
@@ -7,4 +7,6 @@ public interface UserWriteService {
 	User updateProfile(UUID userId, String nickname, String profileImageUrl);
 
 	void updateHelpCounts(UUID requesterId, UUID applicantId);
+
+	void deleteUser(UUID userId);
 }

--- a/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
@@ -54,6 +54,13 @@ public class UserWriteServiceImpl implements UserWriteService {
 		userRepository.saveAll(java.util.List.of(requester, applicant));
 	}
 
+	@Override
+	public void deleteUser(UUID userId) {
+		User user = getUser(userId, "User not found.");
+		user.delete();
+		userRepository.save(user);
+	}
+
 	private int safeCastToInt(long value) {
 		if (value > Integer.MAX_VALUE) {
 			throw new BusinessException(ErrorCode.INVALID_REQUEST, "Help count exceeds maximum limit");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,7 @@ deoham:
     allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:8080
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY:683885f3d0ae05d5d74cb2298f6a2976}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/api/auth/kakao/callback}
   s3:
     region: ${AWS_S3_REGION:ap-northeast-2}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ deoham:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY:}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI:}
   s3:
     region: ${AWS_S3_REGION:ap-northeast-2}

--- a/src/main/resources/db/migration/V20__add_user_soft_delete.sql
+++ b/src/main/resources/db/migration/V20__add_user_soft_delete.sql
@@ -1,0 +1,8 @@
+-- =============================================================
+-- V20: Add soft delete support to users
+-- =============================================================
+
+ALTER TABLE users
+    ADD COLUMN deleted_at TIMESTAMPTZ;
+
+CREATE INDEX idx_users_deleted_at ON users(deleted_at) WHERE deleted_at IS NULL;


### PR DESCRIPTION
## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
회원 탈퇴 기능:
- V20 마이그레이션: users 테이블에 deleted_at 컬럼 추가
- User 엔티티: @Where 어노테이션으로 자동 soft delete 처리
- User.delete() 메서드: deleted_at을 현재 시각으로 설정
- UserWriteService: deleteUser() 메서드 추가
- UserController: DELETE /api/user 엔드포인트 추가

Kakao OAuth 개선:
- KakaoOAuthProperties에 clientSecret 필드 추가
- KakaoOAuthClient: token 요청에 client_secret 포함
- 에러 로깅 개선으로 Kakao API 응답 확인 가능
- 환경 변수 KAKAO_CLIENT_SECRET 추가


## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
