### PR TITLE
refactor: simplify card API responses and update card expiry duration

### DIFF
--- a/src/main/java/com/deoham/card/controller/CardController.java
+++ b/src/main/java/com/deoham/card/controller/CardController.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,178 +43,127 @@ public class CardController {
     private final CardReadService cardReadService;
     private final CardWriteService cardWriteService;
 
-    // ----------------------------------------------------------------
-    // Card (게시물) endpoints
-    // ----------------------------------------------------------------
-
     @Tag(name = "Card")
-    @Operation(
-            summary = "카드 생성",
-            description = """
-                    도움 요청 카드를 생성합니다.
-                    로그인 직후 GET /api/cards/my/active로 진행 중인 카드가 없는 것을 확인한 뒤 호출하는 API입니다.
-                    생성된 카드는 OPEN 상태가 되며 주변 사용자에게 노출됩니다.
-                    기본 만료 시간은 생성 시점 기준 2시간이고, retryCount는 0으로 시작합니다.
-                    """
-    )
+    @Operation(summary = "Create card", description = "Creates a help request card.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "201", description = "생성 성공",
+                    responseCode = "201", description = "Created",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = CardDetailResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400", description = "잘못된 요청 (필수 필드 누락 등)"),
+                    responseCode = "400", description = "Invalid request",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요")
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @PostMapping("/cards")
-    public ResponseEntity<ApiResponse<CardDetailResponse>> createCard(
+    public ResponseEntity<CardDetailResponse> createCard(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "카드 생성 요청 본문", required = true,
+                    description = "Card create request", required = true,
                     content = @Content(schema = @Schema(implementation = CreateCardRequest.class)))
             @Valid @RequestBody CreateCardRequest request
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(cardWriteService.createCard(request, userId)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(cardWriteService.createCard(request, userId));
     }
 
-    @Tag(name = "CardApply")
-    @Operation(
-            summary = "주변 카드 목록 조회",
-            description = """
-                    현재 위치 기준 반경 100m 내 OPEN 상태 카드를 거리순으로 반환합니다.
-                    도움을 제공하려는 사용자가 주변의 도움 요청 카드를 탐색할 때 호출합니다.
-
-                    [페이지네이션]
-                    - 한 번의 요청으로 최대 20개의 카드를 반환합니다.
-                    - cursor 기반 페이지네이션을 사용하여 중복/누락 없이 정확한 조회를 보장합니다.
-                    - 서버는 내부적으로 21개를 조회하여 다음 페이지 존재 여부를 판단합니다.
-                    - 21번째 카드가 있으면 nextCursor를 반환하고, 없으면 nextCursor는 null입니다.
-
-                    [첫 요청]
-                    - cursor 파라미터를 생략하면 가장 가까운 카드부터 반환됩니다.
-
-                    [다음 페이지]
-                    - 응답의 nextCursor를 다음 요청의 cursor 파라미터로 전달합니다.
-                    - nextCursor는 가까운 순서로 20개씩 이어서 조회하기 위한 값입니다.
-                    - nextCursor는 현재 페이지의 마지막 카드(20번째 카드)의 거리와 ID를 조합하여 Base64 인코딩한 값입니다.
-                    - 예: "50.5|e5f6g7h8" → "NTAuNXxlNWY2ZzdoOA=="
-                    - nextCursor 기준 이후의 카드들을 조회하므로 새로운 카드 생성 중에도 중복/누락이 발생하지 않습니다.
-
-                    [마지막 페이지]
-                    - nextCursor가 null이면 더 이상 조회할 카드가 없습니다.
-
-                    목록에서 카드를 선택한 뒤 GET /api/cards/{cardId}로 상세 정보를 확인하고 신청 플로우로 이어집니다.
-                    """
-    )
+    @Tag(name = "Card")
+    @Operation(summary = "Get nearby cards", description = "Returns nearby OPEN cards sorted by distance.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공",
+                    responseCode = "200", description = "OK",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PaginatedCardListResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400", description = "위도/경도 파라미터 누락"),
+                    responseCode = "400", description = "Invalid latitude or longitude",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요")
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping("/cards/nearby")
-    public ResponseEntity<ApiResponse<PaginatedCardListResponse>> getNearbyCards(
-            @Parameter(description = "위도", required = true, example = "37.5326")
+    public ResponseEntity<PaginatedCardListResponse> getNearbyCards(
+            @Parameter(description = "Latitude", required = true, example = "37.5326")
             @RequestParam @NotNull Double latitude,
-
-            @Parameter(description = "경도", required = true, example = "126.9903")
+            @Parameter(description = "Longitude", required = true, example = "126.9903")
             @RequestParam @NotNull Double longitude,
-
-            @Parameter(
-                    description = """
-                            페이지 커서 (선택사항)
-                            - 생략하면 첫 페이지 조회 (가장 가까운 카드부터)
-                            - 다음 페이지: 이전 응답의 nextCursor 값을 사용
-                            - nextCursor가 null이면 더 이상 조회할 카드가 없음
-                            - 형식: 거리|카드ID를 Base64로 인코딩한 값
-                            """,
-                    example = "NTAuNXxhMWIyYzNkNGU1ZjY=")
+            @Parameter(description = "Optional pagination cursor", example = "NTAuNXxhMWIyYzNkNGU1ZjY=")
             @RequestParam(required = false) String cursor
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(cardReadService.getNearbyCards(latitude, longitude, cursor)));
+        return ResponseEntity.ok(cardReadService.getNearbyCards(latitude, longitude, cursor));
     }
 
     @Tag(name = "Card")
-    @Operation(
-            summary = "내 활성 카드 조회",
-            description = """
-                    로그인 직후 가장 먼저 호출해 현재 사용자가 생성한 진행 중 카드가 있는지 확인합니다.
-                    현재 로그인한 사용자의 OPEN 또는 MATCHED 상태 카드를 반환합니다.
-                    OPEN 카드는 아직 매칭되지 않은 도움 요청이고, MATCHED 카드는 신청 접수 후 진행 중인 카드입니다.
-                    활성 카드가 없으면 data가 null이며, 이 경우 사용자는 새 카드를 생성할 수 있습니다.
-                    """
-    )
+    @Operation(summary = "Get my active card", description = "Returns the current user's OPEN or MATCHED card. Returns null when none exists.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공 (활성 카드 없으면 data: null)",
+                    responseCode = "200", description = "OK",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = CardDetailResponse.class))),
+                            schema = @Schema(implementation = CardDetailResponse.class, nullable = true))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요")
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping("/cards/my/active")
-    public ResponseEntity<ApiResponse<CardDetailResponse>> getMyActiveCard() {
+    public ResponseEntity<CardDetailResponse> getMyActiveCard() {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
-        return ResponseEntity.ok(ApiResponse.ok(cardReadService.getMyActiveCard(userId).orElse(null)));
+        return ResponseEntity.ok(cardReadService.getMyActiveCard(userId).orElse(null));
     }
 
     @Tag(name = "Card")
-    @Operation(
-            summary = "카드 상세 조회",
-            description = """
-                    카드 ID로 상세 정보를 반환합니다.
-                    주변 카드 목록에서 특정 카드를 선택했을 때 상세 내용을 확인하는 API입니다.
-                    도움을 제공하려는 사용자는 POST /api/cards/{cardId}/applies로 신청할 수 있습니다.
-                    추후 알림 기능을 위해 사용될 API입니다.
-                    """
-    )
+    @Operation(summary = "Get card detail", description = "Returns detail for a card.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공",
+                    responseCode = "200", description = "OK",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = CardDetailResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음")
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping("/cards/{cardId}")
-    public ResponseEntity<ApiResponse<CardDetailResponse>> getCard(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<CardDetailResponse> getCard(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(cardReadService.getCard(cardId)));
+        return ResponseEntity.ok(cardReadService.getCard(cardId));
     }
 
     @Tag(name = "Card")
-    @Operation(
-            summary = "카드 취소",
-            description = """
-                    OPEN 상태의 카드를 CANCELLED로 변경합니다.
-                    카드 작성자만 호출할 수 있으며, 아직 신청을 수락해 MATCHED가 되기 전의 요청을 취소할 때 사용합니다.
-                    취소된 카드는 활성 카드 조회 대상에서 제외됩니다.
-                    """
-    )
+    @Operation(summary = "Cancel card", description = "Cancels an OPEN card.")
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "204", description = "취소 성공"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "403", description = "Forbidden",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403", description = "카드 작성자가 아님"),
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409", description = "OPEN 상태가 아님 (이미 매칭됐거나 완료됨)")
+                    responseCode = "409", description = "Card status conflict",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @PatchMapping("/cards/{cardId}/cancel")
-    public ResponseEntity<ApiResponse<Void>> cancelCard(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<Void> cancelCard(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
@@ -224,29 +172,29 @@ public class CardController {
     }
 
     @Tag(name = "Card")
-    @Operation(
-            summary = "카드 완료",
-            description = """
-                    MATCHED 상태의 카드를 COMPLETED로 변경합니다.
-                    신청 매칭 후 실제 도움이 완료되었을 때 카드 작성자가 호출합니다.
-                    완료 시 매칭된 신청자의 help_count가 증가하고, 카드는 활성 카드 조회 대상에서 제외됩니다.
-                    """
-    )
+    @Operation(summary = "Complete card", description = "Completes a MATCHED card.")
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "204", description = "완료 성공"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "403", description = "Forbidden",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403", description = "카드 작성자가 아님"),
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409", description = "MATCHED 상태가 아님")
+                    responseCode = "409", description = "Card status conflict",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @PatchMapping("/cards/{cardId}/complete")
-    public ResponseEntity<ApiResponse<Void>> completeCard(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<Void> completeCard(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
@@ -255,30 +203,29 @@ public class CardController {
     }
 
     @Tag(name = "Card")
-    @Operation(
-            summary = "카드 재요청",
-            description = """
-                    OPEN 상태의 카드를 다시 주변 사용자에게 노출하기 위해 재요청합니다.
-                    카드 작성자만 호출할 수 있으며, 최대 3회까지 가능합니다.
-                    재요청 시 retryCount가 1 증가하고 만료 시간이 현재 시점 기준 2시간 뒤로 초기화됩니다.
-                    MATCHED 이후에는 재요청할 수 없습니다.
-                    """
-    )
+    @Operation(summary = "Retry card", description = "Refreshes an OPEN card request.")
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "204", description = "재요청 성공"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "403", description = "Forbidden",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403", description = "카드 작성자가 아님"),
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409", description = "재요청 불가 (OPEN 상태가 아니거나 재요청 횟수 3회 초과)")
+                    responseCode = "409", description = "Card status conflict",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @PatchMapping("/cards/{cardId}/retry")
-    public ResponseEntity<ApiResponse<Void>> retryCard(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<Void> retryCard(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
@@ -286,68 +233,65 @@ public class CardController {
         return ResponseEntity.noContent().build();
     }
 
-    // ----------------------------------------------------------------
-    // CardApply (신청) endpoints
-    // ----------------------------------------------------------------
-
     @Tag(name = "CardApply")
-    @Operation(
-            summary = "신청 제출",
-            description = """
-                    도움을 제공하려는 사용자가 OPEN 상태의 카드에 신청합니다.
-                    일반적인 흐름은 주변 카드 목록 조회 → 신청 제출입니다.
-                    카드 작성자는 본인 카드에 신청할 수 없으며, 카드 1개당 1회만 신청 가능합니다.
-                    신청은 PENDING 상태로 생성되고, 카드 작성자의 수락 또는 거절을 기다리는 절차 없이 바로 매칭됩니다.
-                    """
-    )
+    @Operation(summary = "Submit card apply", description = "Applies to an OPEN card.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "201", description = "신청 성공"),
+                    responseCode = "201", description = "Created",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CardApplySummaryResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403", description = "본인 카드에는 신청 불가"),
+                    responseCode = "403", description = "Forbidden",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음"),
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409", description = "이미 신청했거나 카드가 OPEN 상태가 아님")
+                    responseCode = "409", description = "Card apply conflict",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @PostMapping("/cards/{cardId}/applies")
-    public ResponseEntity<ApiResponse<CardApplySummaryResponse>> submitApply(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<CardApplySummaryResponse> submitApply(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(cardWriteService.submitApply(cardId, userId)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(cardWriteService.submitApply(cardId, userId));
     }
 
     @Tag(name = "CardApply")
-    @Operation(
-            summary = "신청 목록 조회",
-            description = """
-                    카드에 달린 신청 목록을 반환합니다.
-                    카드 작성자만 호출할 수 있으며, 매칭된 신청자 정보를 확인할 때 사용합니다.
-                    """
-    )
+    @Operation(summary = "Get card applies", description = "Returns applies submitted to a card.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공",
+                    responseCode = "200", description = "OK",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             array = @ArraySchema(schema = @Schema(implementation = CardApplySummaryResponse.class)))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401", description = "인증 필요"),
+                    responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403", description = "카드 작성자가 아님"),
+                    responseCode = "403", description = "Forbidden",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404", description = "카드를 찾을 수 없음")
+                    responseCode = "404", description = "Card not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping("/cards/{cardId}/applies")
-    public ResponseEntity<ApiResponse<List<CardApplySummaryResponse>>> getApplies(
-            @Parameter(description = "카드 ID", required = true)
+    public ResponseEntity<List<CardApplySummaryResponse>> getApplies(
+            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
-        return ResponseEntity.ok(ApiResponse.ok(cardReadService.getApplies(cardId, userId)));
+        return ResponseEntity.ok(cardReadService.getApplies(cardId, userId));
     }
-
 }

--- a/src/main/java/com/deoham/card/entity/Card.java
+++ b/src/main/java/com/deoham/card/entity/Card.java
@@ -28,7 +28,7 @@ import org.locationtech.jts.geom.Point;
 public class Card extends BaseEntity {
 
     public static final int MAX_RETRY_COUNT = 3;
-    public static final Duration EXPIRY_DURATION = Duration.ofHours(2);
+    public static final Duration EXPIRY_DURATION = Duration.ofMinutes(30);
 
     @Id
     @UuidGenerator

--- a/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
@@ -105,8 +105,9 @@ public class DefaultCardWriteService implements CardWriteService {
         if (card.getRetryCount() >= Card.MAX_RETRY_COUNT) {
             throw new BusinessException(ErrorCode.CONFLICT, "재요청 횟수를 초과했습니다. (최대 " + Card.MAX_RETRY_COUNT + "회)");
         }
+        Instant retriedAt = Instant.now();
         card.incrementRetryCount();
-        card.updateExpiresAt(Instant.now().plus(Card.EXPIRY_DURATION));
+        card.updateExpiresAt(retriedAt.plus(Card.EXPIRY_DURATION));
     }
 
     @Override

--- a/src/main/java/com/deoham/global/config/OpenApiConfig.java
+++ b/src/main/java/com/deoham/global/config/OpenApiConfig.java
@@ -6,12 +6,10 @@ import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -30,10 +28,6 @@ public class OpenApiConfig {
 						.contact(new Contact()
 								.name("Deoham Team")
 								.email("npmtart1224@naver.com")))
-				.servers(List.of(
-						new Server().url("http://localhost:8080").description("Local"),
-						new Server().url("https://api.deoham.com").description("Production")
-				))
 				.tags(List.of(
 						new Tag().name("Card").description("도움 요청 카드 생성·조회·상태 변경"),
 						new Tag().name("CardApply").description("매칭 신청·수락·거절")

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ jwt:
 
 deoham:
   cors:
-    allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:8080
+    allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:8080,http://127.0.0.1:3000,http://127.0.0.1:5173,http://127.0.0.1:8080
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY:}
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/auth/callback}


### PR DESCRIPTION
## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- Remove ApiResponse wrapper from CardController endpoints, returning data directly
- Standardize operation descriptions to English in Swagger annotations
- Improve error response documentation with proper schema definitions
- Update Card.EXPIRY_DURATION from 2 hours to 30 minutes
- Ensure consistent timestamp usage in retryCard() logic

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
