### PR TITLE
Feat: 카드 뷰 온보딩 플래그 추가 및 자동 업데이트

### DIFF
--- a/src/main/java/com/deoham/card/controller/CardController.java
+++ b/src/main/java/com/deoham/card/controller/CardController.java
@@ -96,7 +96,8 @@ public class CardController {
             @Parameter(description = "Optional pagination cursor", example = "NTAuNXxhMWIyYzNkNGU1ZjY=")
             @RequestParam(required = false) String cursor
     ) {
-        return ResponseEntity.ok(cardReadService.getNearbyCards(latitude, longitude, cursor));
+        UUID userId = AuthenticationUtils.currentPrincipal().orElseThrow().userId();
+        return ResponseEntity.ok(cardReadService.getNearbyCards(latitude, longitude, cursor, userId));
     }
 
     @Tag(name = "Card")

--- a/src/main/java/com/deoham/card/dto/response/PaginatedCardListResponse.java
+++ b/src/main/java/com/deoham/card/dto/response/PaginatedCardListResponse.java
@@ -10,6 +10,9 @@ public record PaginatedCardListResponse(
         List<CardDetailResponse> cards,
 
         @Schema(description = "Cursor for the next page. Pass this value as the cursor query parameter in the next GET /api/cards/nearby request. It is Base64 encoded from the last card's distance and card ID. Null means there are no more cards.")
-        String nextCursor
+        String nextCursor,
+
+        @Schema(description = "Whether the user has seen the card view onboarding")
+        Boolean hasSeenCardViewOnboarding
 ) {
 }

--- a/src/main/java/com/deoham/card/service/CardReadService.java
+++ b/src/main/java/com/deoham/card/service/CardReadService.java
@@ -12,7 +12,7 @@ public interface CardReadService {
 
     MyActiveCardResponse getMyActiveCard(UUID userId);
 
-    PaginatedCardListResponse getNearbyCards(double lat, double lng, String cursor);
+    PaginatedCardListResponse getNearbyCards(double lat, double lng, String cursor, UUID userId);
 
     CardDetailResponse getCard(UUID cardId);
 

--- a/src/main/java/com/deoham/card/service/DefaultCardReadService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardReadService.java
@@ -33,7 +33,7 @@ public class DefaultCardReadService implements CardReadService {
     private final UserRepository userRepository;
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public MyActiveCardResponse getMyActiveCard(UUID userId) {
         var activeCard = cardRepository.findFirstByRequesterIdAndStatusIn(userId, List.of(CardStatus.OPEN, CardStatus.MATCHED))
                 .map(this::toDetailResponse)
@@ -42,12 +42,14 @@ public class DefaultCardReadService implements CardReadService {
         var user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
+        user.markCardViewOnboardingSeen();
+
         return MyActiveCardResponse.of(activeCard, user.isHasCreatedCard());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public PaginatedCardListResponse getNearbyCards(double lat, double lng, String cursor) {
+    public PaginatedCardListResponse getNearbyCards(double lat, double lng, String cursor, UUID userId) {
         CursorData cursorData = parseCursor(cursor);
         List<Object[]> rows = cardRepository.findNearbyCards(lat, lng, cursorData.distance(), cursorData.cardId());
 
@@ -73,7 +75,8 @@ public class DefaultCardReadService implements CardReadService {
                 .toList();
 
         String nextCursor = hasMore ? encodeCursor(((Number) rows.get(PAGE_SIZE - 1)[13]).doubleValue(), rows.get(PAGE_SIZE - 1)[0].toString()) : null;
-        return new PaginatedCardListResponse(cards, nextCursor);
+        Boolean has_seen_card_view_onboarding = userRepository.hasSeenCardViewOnboarding(userId);
+        return new PaginatedCardListResponse(cards, nextCursor, has_seen_card_view_onboarding);
     }
 
     @Override

--- a/src/main/java/com/deoham/user/entity/User.java
+++ b/src/main/java/com/deoham/user/entity/User.java
@@ -76,6 +76,9 @@ public class User extends BaseEntity {
     @Column(name = "has_created_card", nullable = false)
     private boolean hasCreatedCard = false;
 
+    @Column(name = "has_seen_card_view_onboarding", nullable = false)
+    private boolean hasSeenCardViewOnboarding = false;
+
     @Builder
     private User(String firebaseUid, String nickname, String profileImageUrl, GenderType gender, Integer age) {
         this.firebaseUid = firebaseUid != null ? firebaseUid : UUID.randomUUID().toString();
@@ -131,5 +134,9 @@ public class User extends BaseEntity {
 
     public void markCardCreated() {
         this.hasCreatedCard = true;
+    }
+
+    public void markCardViewOnboardingSeen() {
+        this.hasSeenCardViewOnboarding = true;
     }
 }

--- a/src/main/java/com/deoham/user/repository/UserRepository.java
+++ b/src/main/java/com/deoham/user/repository/UserRepository.java
@@ -4,10 +4,20 @@ import com.deoham.user.entity.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByFirebaseUid(String firebaseUid);
 
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT u.hasSeenCardViewOnboarding FROM User u WHERE u.id = :userId")
+    boolean hasSeenCardViewOnboarding(@Param("userId") UUID userId);
+
+    @Modifying
+    @Query("UPDATE User u SET u.hasSeenCardViewOnboarding = true WHERE u.id = :userId")
+    void markCardViewOnboardingSeen(@Param("userId") UUID userId);
 }


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #41  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- User 엔티티에 has_seen_card_view_onboarding 필드 추가 (기본값: false)
- GET /api/cards/my/active 호출 시 플래그 자동으로 true로 설정
- UserRepository에 쿼리 메서드 추가
- PaginatedCardListResponse에 hasSeenCardViewOnboarding 필드 추가

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
