### PR TITLE
Feat: 카드 조회 API에 requester nickname 추가

### DIFF
--- a/src/main/java/com/deoham/card/dto/response/CardDetailResponse.java
+++ b/src/main/java/com/deoham/card/dto/response/CardDetailResponse.java
@@ -16,6 +16,9 @@ public record CardDetailResponse(
         @Schema(description = "Requester ID")
         UUID requesterId,
 
+        @Schema(description = "Requester nickname")
+        String requesterNickname,
+
         @Schema(description = "Requester profile image URL")
         String requesterProfileImageUrl,
 

--- a/src/main/java/com/deoham/card/repository/CardRepository.java
+++ b/src/main/java/com/deoham/card/repository/CardRepository.java
@@ -24,6 +24,7 @@ public interface CardRepository extends JpaRepository<Card, UUID> {
     @Query(value = """
             SELECT c.id,
                    c.requester_id,
+                   u.nickname,
                    u.profile_image_url,
                    c.category::text,
                    c.description,

--- a/src/main/java/com/deoham/card/service/DefaultCardReadService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardReadService.java
@@ -60,21 +60,22 @@ public class DefaultCardReadService implements CardReadService {
                         (UUID) row[0],
                         (UUID) row[1],
                         (String) row[2],
-                        CardCategory.valueOf((String) row[3]),
-                        (String) row[4],
-                        toInstant(row[5]),
-                        CardStatus.valueOf((String) row[6]),
-                        row[7] != null ? PreferredGender.valueOf((String) row[7]) : null,
-                        (Integer) row[8],
+                        (String) row[3],
+                        CardCategory.valueOf((String) row[4]),
+                        (String) row[5],
+                        toInstant(row[6]),
+                        CardStatus.valueOf((String) row[7]),
+                        row[8] != null ? PreferredGender.valueOf((String) row[8]) : null,
                         (Integer) row[9],
                         (Integer) row[10],
-                        toInstant(row[11]),
+                        (Integer) row[11],
                         toInstant(row[12]),
-                        ((Number) row[13]).doubleValue()
+                        toInstant(row[13]),
+                        ((Number) row[14]).doubleValue()
                 ))
                 .toList();
 
-        String nextCursor = hasMore ? encodeCursor(((Number) rows.get(PAGE_SIZE - 1)[13]).doubleValue(), rows.get(PAGE_SIZE - 1)[0].toString()) : null;
+        String nextCursor = hasMore ? encodeCursor(((Number) rows.get(PAGE_SIZE - 1)[14]).doubleValue(), rows.get(PAGE_SIZE - 1)[0].toString()) : null;
         Boolean has_seen_card_view_onboarding = userRepository.hasSeenCardViewOnboarding(userId);
         return new PaginatedCardListResponse(cards, nextCursor, has_seen_card_view_onboarding);
     }
@@ -113,6 +114,7 @@ public class DefaultCardReadService implements CardReadService {
         return new CardDetailResponse(
                 card.getId(),
                 card.getRequester().getId(),
+                card.getRequester().getNickname(),
                 card.getRequester().getProfileImageUrl(),
                 card.getCategory(),
                 card.getDescription(),

--- a/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
@@ -64,6 +64,7 @@ public class DefaultCardWriteService implements CardWriteService {
         return new CardDetailResponse(
                 card.getId(),
                 card.getRequester().getId(),
+                card.getRequester().getNickname(),
                 card.getRequester().getProfileImageUrl(),
                 card.getCategory(),
                 card.getDescription(),

--- a/src/main/java/com/deoham/user/repository/UserSocialAccountRepository.java
+++ b/src/main/java/com/deoham/user/repository/UserSocialAccountRepository.java
@@ -14,4 +14,6 @@ public interface UserSocialAccountRepository extends JpaRepository<UserSocialAcc
 	Optional<UserSocialAccount> findByRefreshToken(String refreshToken);
 
 	List<UserSocialAccount> findAllByUser_Id(UUID userId);
+
+	void deleteAllByUser_Id(UUID userId);
 }

--- a/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
@@ -8,6 +8,7 @@ import com.deoham.global.exception.BusinessException;
 import com.deoham.global.exception.ErrorCode;
 import com.deoham.user.entity.User;
 import com.deoham.user.repository.UserRepository;
+import com.deoham.user.repository.UserSocialAccountRepository;
 import com.deoham.user.service.UserWriteService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class UserWriteServiceImpl implements UserWriteService {
     private final UserRepository userRepository;
 	private final CardRepository cardRepository;
 	private final CardApplyRepository cardApplyRepository;
+	private final UserSocialAccountRepository userSocialAccountRepository;
 
     @Override
     public User updateProfile(UUID userId, String nickname, String profileImageUrl) {
@@ -59,6 +61,7 @@ public class UserWriteServiceImpl implements UserWriteService {
 		User user = getUser(userId, "User not found.");
 		user.delete();
 		userRepository.save(user);
+		userSocialAccountRepository.deleteAllByUser_Id(userId);
 	}
 
 	private int safeCastToInt(long value) {


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #41 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- GET /api/cards/nearby에서 카드 정보 반환 시 requester의 nickname을 포함하도록 수정
- CardDetailResponse에 requesterNickname 필드 추가
- CardRepository SQL 쿼리에 u.nickname 추가
- DefaultCardReadService와 DefaultCardWriteService의 CardDetailResponse 생성 코드 업데이트

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
