### PR TITLE
Fix: CI 워크플로우에서 잘못된 Docker 컨테이너 이름 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           # DB 연결 확인
           echo "Testing database connectivity..."
           for i in {1..10}; do
-            if docker exec deoham-be-postgres-1 psql -U deoham -d deoham -c "SELECT 1" &>/dev/null; then
+            if docker exec deoham-postgres-1 psql -U deoham -d deoham -c "SELECT 1" &>/dev/null; then
               echo "✓ Database is ready"
               break
             fi
@@ -249,7 +249,7 @@ jobs:
           # Redis 연결 확인
           echo "Testing Redis connectivity..."
           for i in {1..10}; do
-            if docker exec deoham-be-redis-1 redis-cli ping &>/dev/null; then
+            if docker exec deoham-redis-1 redis-cli ping &>/dev/null; then
               echo "✓ Redis is ready"
               break
             fi


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #59 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- compose.yaml의 서비스명이 postgres/redis이므로 생성되는 컨테이너명은 deoham-postgres-1, deoham-redis-1입니다. 오래된 deoham-be-postgres-1, deoham-be-redis-1 컨테이너명으로 인해 배포 시 연결 테스트가 실패하는 문제를 해결했습니다.

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
