### PR TITLE
Fix: Docker health check를 curl 기반으로 변경 및 타이밍 조정

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,6 +1,8 @@
 FROM eclipse-temurin:17-jre-jammy
 WORKDIR /app
 RUN groupadd --system app && useradd --system --gid app --home /app --shell /bin/false app
+# Health check를 위해 curl 설치
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 # CI 에서 build/libs 의 부팅 JAR 을 컨텍스트 루트로 복사해 둔다 (.dockerignore 가 build/ 를 제외하므로)
 COPY app.jar app.jar
 RUN chown app:app /app/app.jar

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,11 +17,11 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health", "||", "exit", "1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 40s
+      retries: 5
+      start_period: 50s
     restart: unless-stopped
 
   postgres:


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #59 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- Dockerfile.deploy에 curl 설치하여 health check 도구 확보
- /dev/tcp 방식에서 실제 /actuator/health endpoint 확인으로 변경
- start_period를 50초로 증가하여 DispatcherServlet 초기화 완료 대기
- retries는 5로 감소 (start_period가 충분함)

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
