### PR TITLE
Fix: CI/CD health check retry 대기 시간 조정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           max_attempts=5
 
           for attempt in $(seq 1 $max_attempts); do
-            wait_time=$((attempt * 5))  # 5s, 10s, 15s...
+            wait_time=$((60 + (attempt - 1) * 5))
 
             # Readiness probe
             if curl -sf http://localhost:8080/actuator/health/readiness &>/dev/null; then


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #59 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 초기 대기 시간을 60초로 설정
- 각 재시도마다 5초씩 증가 (60s, 65s, 70s, 75s, 80s)
- 애플리케이션 시작 시간 여유 확보

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
