### PR TITLE
Fix: Metaspace OOM 해결 - MaxMetaspaceSize 증가

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -10,5 +10,5 @@ USER app
 EXPOSE 8080
 # t3.micro(1GB) + 2G swap 기준으로 힙을 명시적으로 캡한다.
 # (MaxRAMPercentage=75 는 컨테이너 메모리 제한이 없으면 호스트 전체의 75%를 노려 OOM 유발)
-ENV JAVA_OPTS="-Xms128m -Xmx448m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTS="-Xms128m -Xmx448m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #59 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- MaxMetaspaceSize 128m → 256m으로 증가
- springdoc-openapi 초기화 시 클래스 로드 많음으로 인한 Metaspace 부족 해결
- t3.micro(1GB + 2GB swap) 환경에 맞춰 조정

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
