### PR TITLE
Fix: WebSocket 핸드셰이크 401 오류 해결 - /ws permitAll 추가

### DIFF
--- a/src/main/java/com/deoham/global/config/SecurityConfig.java
+++ b/src/main/java/com/deoham/global/config/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
 			"/v3/api-docs/**",
 			"/api/auth/kakao",
 			"/api/auth/kakao/callback",
-			"/api/auth/refresh"
+			"/api/auth/refresh",
+			"/ws",
+			"/ws/**"
 	};
 
 	private final JwtProperties jwtProperties;


### PR DESCRIPTION
STOMP CONNECT 프레임에서 JWT를 검증하도록 설계되어 있었지만
SecurityConfig의 authorizeHttpRequests에 /ws가 누락되어 HTTP 업그레이드 요청 자체가 anyRequest().authenticated()에 걸려
핸드셰이크 단계에서 401을 반환하던 문제를 수정.


Claude-Session: https://claude.ai/code/session_01E9wVVfKHV2tRfMNtM6wNuq

\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #3 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
