### PR TITLE
FEAT: 카드 만료 스케줄러 구현

### DIFF
--- a/src/main/java/com/deoham/DeohamApplication.java
+++ b/src/main/java/com/deoham/DeohamApplication.java
@@ -2,8 +2,10 @@ package com.deoham;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DeohamApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/deoham/card/repository/CardRepository.java
+++ b/src/main/java/com/deoham/card/repository/CardRepository.java
@@ -17,6 +17,8 @@ public interface CardRepository extends JpaRepository<Card, UUID> {
 
     Optional<Card> findFirstByRequesterIdAndStatusIn(UUID requesterId, List<CardStatus> statuses);
 
+    List<Card> findByStatusInAndExpiresAtBefore(List<CardStatus> statuses, java.time.Instant expiresAt);
+
     @Query("""
             SELECT c FROM Card c
             JOIN FETCH c.requester

--- a/src/main/java/com/deoham/card/scheduler/CardScheduler.java
+++ b/src/main/java/com/deoham/card/scheduler/CardScheduler.java
@@ -1,0 +1,26 @@
+package com.deoham.card.scheduler;
+
+import com.deoham.card.service.CardWriteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CardScheduler {
+
+    private final CardWriteService cardWriteService;
+
+    @Scheduled(fixedDelay = 60000)
+    public void expireCards() {
+        try {
+            log.debug("Starting card expiration check...");
+            cardWriteService.expireCards();
+            log.debug("Card expiration check completed");
+        } catch (Exception e) {
+            log.error("Error during card expiration check", e);
+        }
+    }
+}

--- a/src/main/java/com/deoham/card/service/CardWriteService.java
+++ b/src/main/java/com/deoham/card/service/CardWriteService.java
@@ -19,4 +19,6 @@ public interface CardWriteService {
     CardApplySummaryResponse submitApply(UUID cardId, UUID applicantId);
 
     void cancelApply(UUID cardId, UUID userId);
+
+    void expireCards();
 }

--- a/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
+++ b/src/main/java/com/deoham/card/service/DefaultCardWriteService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -189,6 +190,16 @@ public class DefaultCardWriteService implements CardWriteService {
         }
 
         cardApplyRepository.delete(apply);
+    }
+
+    @Override
+    @Transactional
+    public void expireCards() {
+        List<Card> expiredCards = cardRepository.findByStatusInAndExpiresAtBefore(
+                List.of(CardStatus.OPEN, CardStatus.MATCHED),
+                Instant.now()
+        );
+        expiredCards.forEach(card -> card.updateStatus(CardStatus.CANCELLED));
     }
 
     private Card findCardAndValidateOwner(UUID cardId, UUID userId) {

--- a/src/test/java/com/deoham/card/service/CardExpirationTest.java
+++ b/src/test/java/com/deoham/card/service/CardExpirationTest.java
@@ -1,0 +1,230 @@
+package com.deoham.card.service;
+
+import com.deoham.TestcontainersConfiguration;
+import com.deoham.card.dto.request.CreateCardRequest;
+import com.deoham.card.entity.Card;
+import com.deoham.card.entity.CardCategory;
+import com.deoham.card.entity.CardStatus;
+import com.deoham.card.entity.PreferredGender;
+import com.deoham.card.repository.CardRepository;
+import com.deoham.user.entity.User;
+import com.deoham.user.repository.UserRepository;
+import com.deoham.user.service.UserWriteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@Transactional
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Card 만료 기능 테스트")
+class CardExpirationTest {
+
+    @Autowired
+    private CardWriteService cardWriteService;
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .firebaseUid("firebase_test_" + UUID.randomUUID())
+                .nickname("test_user")
+                .build();
+        user = userRepository.save(user);
+        userId = user.getId();
+    }
+
+    @Test
+    @DisplayName("카드 생성 후 30분이 경과하면 CANCELLED 상태로 변경된다")
+    void cardIsExpiredAfter30Minutes() {
+        // Given
+        CreateCardRequest request = new CreateCardRequest(
+                CardCategory.MEAL,
+                "test description",
+                37.5,
+                127.0,
+                PreferredGender.ANY,
+                20,
+                40
+        );
+
+        var cardDetail = cardWriteService.createCard(request, userId);
+        UUID cardId = cardDetail.id();
+
+        Card card = cardRepository.findById(cardId).orElseThrow();
+        assertThat(card.getStatus()).isEqualTo(CardStatus.OPEN);
+        assertThat(card.getExpiresAt()).isBetween(
+                Instant.now().plus(Card.EXPIRY_DURATION).minusSeconds(1),
+                Instant.now().plus(Card.EXPIRY_DURATION).plusSeconds(1)
+        );
+
+        // When: expiresAt을 현재 시간으로 설정하여 만료 상태 시뮬레이션
+        card.updateExpiresAt(Instant.now().minusSeconds(1));
+        cardRepository.save(card);
+
+        // cardWriteService.expireCards() 호출
+        cardWriteService.expireCards();
+
+        // Then
+        Card expiredCard = cardRepository.findById(cardId).orElseThrow();
+        assertThat(expiredCard.getStatus()).isEqualTo(CardStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("retry 후 만료 시간이 30분으로 재설정된다")
+    void expirationTimeResetAfterRetry() {
+        // Given
+        CreateCardRequest request = new CreateCardRequest(
+                CardCategory.MEAL,
+                "test description",
+                37.5,
+                127.0,
+                PreferredGender.ANY,
+                20,
+                40
+        );
+
+        var cardDetail = cardWriteService.createCard(request, userId);
+        UUID cardId = cardDetail.id();
+
+        Card card = cardRepository.findById(cardId).orElseThrow();
+        Instant originalExpiresAt = card.getExpiresAt();
+
+        // When: retry 실행
+        cardWriteService.retryCard(cardId, userId);
+
+        // Then
+        Card retriedCard = cardRepository.findById(cardId).orElseThrow();
+        assertThat(retriedCard.getRetryCount()).isEqualTo(1);
+        assertThat(retriedCard.getExpiresAt()).isAfter(originalExpiresAt);
+        assertThat(retriedCard.getExpiresAt()).isBetween(
+                Instant.now().plus(Card.EXPIRY_DURATION).minusSeconds(1),
+                Instant.now().plus(Card.EXPIRY_DURATION).plusSeconds(1)
+        );
+    }
+
+    @Test
+    @DisplayName("retry 후 30분이 경과하면 다시 CANCELLED 상태로 변경된다")
+    void cardIsExpiredAfterRetryExpiration() {
+        // Given
+        CreateCardRequest request = new CreateCardRequest(
+                CardCategory.MEAL,
+                "test description",
+                37.5,
+                127.0,
+                PreferredGender.ANY,
+                20,
+                40
+        );
+
+        var cardDetail = cardWriteService.createCard(request, userId);
+        UUID cardId = cardDetail.id();
+
+        // When: retry 실행
+        cardWriteService.retryCard(cardId, userId);
+
+        Card retriedCard = cardRepository.findById(cardId).orElseThrow();
+        assertThat(retriedCard.getStatus()).isEqualTo(CardStatus.OPEN);
+        assertThat(retriedCard.getRetryCount()).isEqualTo(1);
+
+        // expiresAt을 현재 시간으로 설정하여 만료 상태 시뮬레이션
+        retriedCard.updateExpiresAt(Instant.now().minusSeconds(1));
+        cardRepository.save(retriedCard);
+
+        // expireCards() 호출
+        cardWriteService.expireCards();
+
+        // Then
+        Card expiredCard = cardRepository.findById(cardId).orElseThrow();
+        assertThat(expiredCard.getStatus()).isEqualTo(CardStatus.CANCELLED);
+        assertThat(expiredCard.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("최대 3회까지 retry 가능하고, 3회 이후에는 에러 발생")
+    void maxRetryCountIs3() {
+        // Given
+        CreateCardRequest request = new CreateCardRequest(
+                CardCategory.MEAL,
+                "test description",
+                37.5,
+                127.0,
+                PreferredGender.ANY,
+                20,
+                40
+        );
+
+        var cardDetail = cardWriteService.createCard(request, userId);
+        UUID cardId = cardDetail.id();
+
+        // When & Then
+        cardWriteService.retryCard(cardId, userId);
+        assertThat(cardRepository.findById(cardId).orElseThrow().getRetryCount()).isEqualTo(1);
+
+        cardWriteService.retryCard(cardId, userId);
+        assertThat(cardRepository.findById(cardId).orElseThrow().getRetryCount()).isEqualTo(2);
+
+        cardWriteService.retryCard(cardId, userId);
+        assertThat(cardRepository.findById(cardId).orElseThrow().getRetryCount()).isEqualTo(3);
+
+        // 4번째 retry는 실패해야 함
+        var finalCard = cardRepository.findById(cardId).orElseThrow();
+        var exception = org.junit.jupiter.api.Assertions.assertThrows(
+                com.deoham.global.exception.BusinessException.class,
+                () -> cardWriteService.retryCard(cardId, userId)
+        );
+        assertThat(exception.getMessage()).contains("재요청 횟수를 초과했습니다");
+    }
+
+    @Test
+    @DisplayName("expireCards()는 OPEN 상태의 만료된 카드만 CANCELLED로 변경한다")
+    void expireCardsOnlyAffectsOpenCards() {
+        // Given
+        CreateCardRequest request = new CreateCardRequest(
+                CardCategory.MEAL,
+                "test description",
+                37.5,
+                127.0,
+                PreferredGender.ANY,
+                20,
+                40
+        );
+
+        var cardDetail = cardWriteService.createCard(request, userId);
+        UUID cardId = cardDetail.id();
+
+        Card card = cardRepository.findById(cardId).orElseThrow();
+        // 카드를 CANCELLED로 수동 설정
+        card.updateStatus(CardStatus.CANCELLED);
+        card.updateExpiresAt(Instant.now().minusSeconds(1));
+        cardRepository.save(card);
+
+        // When
+        cardWriteService.expireCards();
+
+        // Then: 상태가 유지되어야 함
+        Card unchangedCard = cardRepository.findById(cardId).orElseThrow();
+        assertThat(unchangedCard.getStatus()).isEqualTo(CardStatus.CANCELLED);
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #7 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- CardScheduler 추가: 1분마다 만료된 카드(expiresAt <= now())를 CANCELLED로 변경
- CardRepository에 findByStatusInAndExpiresAtBefore() 쿼리 메서드 추가
- CardWriteService에 expireCards() 메서드 추가
- DeohamApplication에 @EnableScheduling 추가
- 만료 기능 통합 테스트 5개 추가 (전부 PASS)

카드 생성 후 30분 경과 시 자동으로 만료되며, retry 후 만료 시간이 30분 재설정됨

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
