### PR TITLE
[Feat] nginx 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,9 @@ jobs:
         run: |
           ssh -i private_key.pem -o StrictHostKeyChecking=no \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            "mkdir -p ~/deoham/monitoring"
+            "mkdir -p ~/deoham/monitoring ~/deoham/nginx"
           scp -i private_key.pem -o StrictHostKeyChecking=no \
-            -r compose.yaml monitoring .env \
+            -r compose.yaml monitoring nginx .env \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:~/deoham/
 
       # B. EC2 는 빌드 없이 GHCR 에서 pull 만 한다

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,18 @@ jobs:
           free -h
           ENDSSH
 
+      # C. Let's Encrypt 인증서 자동 갱신 cron 보장 (idempotent, 인증서는 최초 1회 수동 발급 필요)
+      - name: Ensure certbot renewal cron on EC2 (idempotent)
+        run: |
+          ssh -i private_key.pem -o StrictHostKeyChecking=no \
+            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} 'bash -s' << 'ENDSSH'
+          set -e
+          CRON_CMD="cd ~/deoham && docker compose run --rm certbot renew --quiet && docker compose exec -T nginx nginx -s reload"
+          ( crontab -l 2>/dev/null | grep -vF "docker compose run --rm certbot renew" ; echo "0 3 * * * $CRON_CMD >> ~/deoham/certbot-renew.log 2>&1" ) | crontab -
+          echo "certbot renewal cron ensured:"
+          crontab -l | grep certbot
+          ENDSSH
+
       - name: Prepare EC2 directory & transfer files
         run: |
           ssh -i private_key.pem -o StrictHostKeyChecking=no \
@@ -218,6 +230,17 @@ jobs:
           echo "=== Pull & start ==="
           docker compose down
           docker compose pull
+
+          # 인증서가 이미 있으면 HTTPS 서버 블록을 기동 전에 활성화한다.
+          # (인증서 없이 ssl.conf 가 conf.d 에 있으면 nginx 기동 실패 → 최초 발급 전에는 HTTP-only 로 기동)
+          echo "=== Enable HTTPS config if certificate exists ==="
+          if docker compose run --rm --entrypoint sh certbot -c 'test -e /etc/letsencrypt/live/piec.store/fullchain.pem' 2>/dev/null; then
+            cp nginx/ssl.conf nginx/conf.d/ssl.conf
+            echo "✓ Existing certificate found — ssl.conf enabled"
+          else
+            echo "No certificate yet — starting HTTP-only (will issue after startup)"
+          fi
+
           docker compose up -d
 
           echo "=== Prune old images ==="
@@ -270,6 +293,7 @@ jobs:
           echo ""
           echo "=== Checking deoham-app-1 container health ==="
           max_attempts=5
+          wait_time=15
           healthy=0
 
           for attempt in $(seq 1 $max_attempts); do
@@ -305,6 +329,37 @@ jobs:
             echo "=== Redis logs ==="
             docker compose logs --tail=100 redis || true
             exit 1
+          fi
+
+          echo ""
+          echo "=== Ensure Let's Encrypt certificate (piec.store) ==="
+          if [ ! -f nginx/conf.d/ssl.conf ]; then
+            # nginx 가 떠서 ACME challenge(/.well-known/acme-challenge/)를 서빙할 수 있을 때까지 대기
+            for i in {1..12}; do
+              nginx_state=$(docker inspect deoham-nginx-1 --format '{{.State.Status}}' 2>/dev/null || echo "none")
+              [ "$nginx_state" = "running" ] && break
+              echo "  Waiting for nginx... ($i/12)"
+              sleep 5
+            done
+
+            if docker compose run --rm certbot certonly --webroot -w /var/www/certbot \
+                 -d piec.store -d www.piec.store \
+                 --email toosee1005@gmail.com --agree-tos --no-eff-email --non-interactive; then
+              cp nginx/ssl.conf nginx/conf.d/ssl.conf
+              docker compose exec -T nginx nginx -s reload
+              echo "✓ Certificate issued & HTTPS enabled"
+            else
+              # 발급 실패(LE rate limit 등)로 배포 전체를 실패시키지는 않는다 — HTTP 로는 계속 서비스
+              echo "⚠ Certificate issuance failed — serving HTTP-only. Check logs and re-deploy."
+            fi
+          fi
+
+          echo ""
+          echo "=== HTTPS smoke test ==="
+          if curl -sf --resolve piec.store:443:127.0.0.1 https://piec.store/actuator/health > /dev/null; then
+            echo "✓ https://piec.store/actuator/health OK"
+          else
+            echo "⚠ HTTPS health check failed (certificate may not be issued yet)"
           fi
 
           echo ""

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,8 @@ services:
       - "443:443"
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - deoham_certbot_conf:/etc/letsencrypt:ro
+      - deoham_certbot_www:/var/www/certbot:ro
     depends_on:
       app:
         condition: service_healthy
@@ -40,6 +42,15 @@ services:
       retries: 5
       start_period: 10s
     restart: unless-stopped
+
+  # 상시 구동 서비스가 아님 — `docker compose up -d` 대상에서 제외되고
+  # 인증서 최초 발급/갱신 시에만 `docker compose run --rm certbot ...` 로 실행
+  certbot:
+    image: certbot/certbot:latest
+    profiles: ["certbot"]
+    volumes:
+      - deoham_certbot_conf:/etc/letsencrypt
+      - deoham_certbot_www:/var/www/certbot
 
   postgres:
     image: postgis/postgis:16-3.4
@@ -193,3 +204,5 @@ volumes:
   deoham_alertmanager_data:
   deoham_loki_data:
   deoham_grafana_data:
+  deoham_certbot_conf:
+  deoham_certbot_www:

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,8 +9,7 @@ services:
     # volumes:
     #   - app_logs:/app/logs
     #   - ./secrets/fcm-service-account.json:/app/secrets/fcm-service-account.json:ro
-    ports:
-      - "80:8080"
+    # 외부 노출 금지 — nginx가 리버스 프록시로 80/443만 공개
     depends_on:
       postgres:
         condition: service_healthy
@@ -22,6 +21,24 @@ services:
       timeout: 5s
       retries: 5
       start_period: 50s
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   postgres:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,31 @@
+upstream app {
+    server app:8080;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 20m;
+
+    # STOMP(WebSocket) 채팅 엔드포인트 — Upgrade 헤더 필요
+    location /ws {
+        proxy_pass http://app;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;
+    }
+
+    location / {
+        proxy_pass http://app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/ssl.conf
+++ b/nginx/ssl.conf
@@ -1,17 +1,22 @@
-upstream app {
-    server app:8080;
-}
-
+# HTTPS(443) 서버 블록 — piec.store
+#
+# 주의: 인증서 파일이 없는 상태에서 이 파일이 conf.d/ 에 있으면 nginx 기동이 실패한다.
+# 그래서 저장소에서는 conf.d/ 밖(nginx/ssl.conf)에 두고,
+# 배포 스크립트(ci.yml)가 Let's Encrypt 인증서 존재를 확인한 뒤 conf.d/ssl.conf 로 복사해 활성화한다.
 server {
-    listen 80;
-    server_name _;
+    listen 443 ssl;
+    http2 on;
+    server_name piec.store www.piec.store;
+
+    ssl_certificate     /etc/letsencrypt/live/piec.store/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/piec.store/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
 
     client_max_body_size 20m;
-
-    # Let's Encrypt(certbot) 도메인 소유권 검증용 — webroot 방식
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
 
     # STOMP(WebSocket) 채팅 엔드포인트 — Upgrade 헤더 필요
     location /ws {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -19,6 +19,14 @@ resource "aws_security_group" "app" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # HTTPS
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # 앱 직접 접근 (테스트용)
   ingress {
     from_port   = 8080
@@ -50,6 +58,12 @@ resource "aws_instance" "app" {
   root_block_device {
     volume_size = 30
     volume_type = "gp3"
+  }
+
+  # AMI data source가 최신 이미지를 다시 조회하면서 발생하는
+  # 의도치 않은 인스턴스 재생성(운영 DB 볼륨 유실) 방지
+  lifecycle {
+    ignore_changes = [ami]
   }
 
   # Docker + Docker Compose 자동 설치


### PR DESCRIPTION
\## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #3 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
  ### 인프라 (Terraform)                                                                                                                                                                                                                                                                                                      
  - EC2 보안그룹에 443(HTTPS) 인바운드 규칙 추가 (apply 완료)                                                                                                                                                                                                                                                                 
  - `aws_instance`에 `lifecycle { ignore_changes = [ami] }` 추가 — AMI data source가 최신 이미지를 조회하면서 인스턴스가 의도치 않게 재생성(→ DB 볼륨 유실)되는 것 방지                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
  ### nginx 리버스 프록시 도입                                                                                                                                                                                                                                                                                                
  - nginx가 80/443을 수신하고 app 컨테이너(8080)는 내부 노출만 하도록 변경                                                                                                                                                                                                                                                    
  - `nginx/conf.d/default.conf` — HTTP(80): API 프록시 + WebSocket(`/ws`) 업그레이드 + Let's Encrypt ACME challenge(webroot) 서빙                                                                                                                                                                                             
  - `nginx/ssl.conf` — HTTPS(443): `piec.store`/`www.piec.store` 대상 TLS 1.2/1.3 + 프록시. 인증서 없이 `conf.d`에 있으면 nginx 기동이 실패하므로 저장소에서는 conf.d 밖에 두고, 배포 스크립트가 인증서 확인 후 활성화                                                                                                        
                                                                                                                                                                                                                                                                                                                              
  ### HTTPS 인증서 자동화 (ci.yml)                                                                                                                                                                                                                                                                                            
  - 배포 시 인증서가 이미 있으면 → 기동 전에 `ssl.conf` 활성화 (처음부터 HTTPS로 기동)                                                                                                                                                                                                                                        
  - 인증서가 없으면(최초 배포) → HTTP-only로 기동 후 certbot이 webroot 방식으로 Let's Encrypt 인증서 발급 → `ssl.conf` 활성화 + nginx reload                                                                                                                                                                                  
  - 발급 실패 시 배포는 실패시키지 않고 HTTP-only로 서비스 유지 (경고 로그만 출력)                                                                                                                                                                                                                                            
  - 매일 03시 `certbot renew` cron 자동 등록 (idempotent) — 90일 만료 자동 갱신                                                                                                                                                                                                                                               
  - 배포 마지막에 `https://piec.store/actuator/health` 스모크 테스트 추가                                                                                                                                                                                                                                                     
  - (버그 수정) 헬스체크 재시도 루프의 `$wait_time` 미정의로 앱이 unhealthy일 때 진단 로그 없이 스크립트가 죽던 문제 수정                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                              
  ## ✔️ 체크 리스트                                                                                                                                                                                                                                                                                                           
  - [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)                                                                                                                                                                                                                                                 
  - [x]] 업한 API에 대해 적절한 **예외처리**가 이루어졌는가? (인증서 발급 실패 시 HTTP-only 폴백)                                                                                                                                                                                                                            
  - [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (배포 스크립트 각 단계 로그 출력)                                                                                                                                                                                                                            
  - [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가? (compose config / nginx -t 문법 검증 완료)                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                              
  ## ↗️ 개선 사항                                                                                                                                                                                                                                                                                                             
  - HTTPS 정상 동작 확인 후 80 포트를 HTTPS 리다이렉트로 전환할지 결정 (현재는 안전한 롤아웃을 위해 HTTP도 그대로 서비스)                                                                                                                                                                                                     
  - 보안그룹의 8080 직접 접근 규칙은 nginx 안정화 후 제거 검토

## 📔 참고 자료
- 선택 사항
