### PR TITLE
FIX: certbot 갱신 cron 등록 스텝이 빈 crontab에서 실패하던 문제 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,8 @@ jobs:
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} 'bash -s' << 'ENDSSH'
           set -e
           CRON_CMD="cd ~/deoham && docker compose run --rm certbot renew --quiet && docker compose exec -T nginx nginx -s reload"
-          ( crontab -l 2>/dev/null | grep -vF "docker compose run --rm certbot renew" ; echo "0 3 * * * $CRON_CMD >> ~/deoham/certbot-renew.log 2>&1" ) | crontab -
+          # grep -v 는 결과가 0줄이면 exit 1 을 반환하므로(빈 crontab 등) `|| true` 로 set -e 중단을 방지
+          ( crontab -l 2>/dev/null | grep -vF "docker compose run --rm certbot renew" || true ; echo "0 3 * * * $CRON_CMD >> ~/deoham/certbot-renew.log 2>&1" ) | crontab -
           echo "certbot renewal cron ensured:"
           crontab -l | grep certbot
           ENDSSH


### PR DESCRIPTION
## 🚀 관련 이슈
- #80 후속 수정

## 🔑 주요 변경사항
- 배포 잡의 certbot 갱신 cron 등록 스텝이 빈 crontab에서 실패하던 버그 수정
  - `grep -v`는 선택된 줄이 0줄이면 exit 1을 반환 → `set -e`로 서브셸 중단 → 빈 crontab 설치 → 검증 `grep certbot`에서 스텝 실패
  - 이 스텝이 파일 전송/배포보다 먼저 실패해서 nginx·인증서 배포가 실행되지 못했음
- `|| true` 추가로 해결, 로컬에서 3가지 crontab 시나리오(빈 crontab / certbot 줄만 존재 / 기존 cron 보존) 검증 완료

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가? (셸 시나리오 시뮬레이션 검증)

## 📔 참고 자료
- 머지 후 배포 로그에서 `✓ Certificate issued & HTTPS enabled` 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMTEnW4MHxyPYSbNuso8J6