### PR TITLE
FIX: 배포 스크립트 조기 종료(stdin 소비)로 서비스가 내려가던 문제 긴급 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,8 @@ jobs:
           # 인증서가 이미 있으면 HTTPS 서버 블록을 기동 전에 활성화한다.
           # (인증서 없이 ssl.conf 가 conf.d 에 있으면 nginx 기동 실패 → 최초 발급 전에는 HTTP-only 로 기동)
           echo "=== Enable HTTPS config if certificate exists ==="
-          if docker compose run --rm --entrypoint sh certbot -c 'test -e /etc/letsencrypt/live/piec.store/fullchain.pem' 2>/dev/null; then
+          # </dev/null 필수 — docker compose run 이 stdin 을 attach 하면 heredoc 의 나머지 스크립트를 삼켜버린다
+          if docker compose run --rm --entrypoint sh certbot -c 'test -e /etc/letsencrypt/live/piec.store/fullchain.pem' </dev/null 2>/dev/null; then
             cp nginx/ssl.conf nginx/conf.d/ssl.conf
             echo "✓ Existing certificate found — ssl.conf enabled"
           else
@@ -345,9 +346,9 @@ jobs:
 
             if docker compose run --rm certbot certonly --webroot -w /var/www/certbot \
                  -d piec.store -d www.piec.store \
-                 --email toosee1005@gmail.com --agree-tos --no-eff-email --non-interactive; then
+                 --email toosee1005@gmail.com --agree-tos --no-eff-email --non-interactive </dev/null; then
               cp nginx/ssl.conf nginx/conf.d/ssl.conf
-              docker compose exec -T nginx nginx -s reload
+              docker compose exec -T nginx nginx -s reload </dev/null
               echo "✓ Certificate issued & HTTPS enabled"
             else
               # 발급 실패(LE rate limit 등)로 배포 전체를 실패시키지는 않는다 — HTTP 로는 계속 서비스


### PR DESCRIPTION
## 🚨 긴급
직전 배포(#94 머지)에서 `docker compose down`만 실행되고 `up -d`가 실행되지 않아 **현재 dev 서버가 내려간 상태**입니다. 머지 즉시 배포가 돌면서 복구됩니다.

## 🔑 주요 변경사항
- `ssh 'bash -s' << heredoc` 방식에서 `docker compose run`(기본 interactive)이 heredoc의 나머지 스크립트를 stdin으로 삼켜버려, 인증서 확인 직후 스크립트가 exit 0으로 조기 종료되던 버그 수정
  - 증상: `compose down` 후 `up -d` 미실행 → 전 컨테이너 정지, CI는 성공으로 표시
- stdin을 attach하는 `docker compose run`/`exec` 호출 3곳에 `</dev/null` 부착

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가?
- [x] YAML 문법 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMTEnW4MHxyPYSbNuso8J6