### PR TITLE
REF: 컨트롤러-Swagger 문서 분리

### DIFF
--- a/src/main/java/com/deoham/auth/controller/AuthController.java
+++ b/src/main/java/com/deoham/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.deoham.auth.controller;
 
+import com.deoham.auth.controller.docs.AuthControllerDocs;
 import com.deoham.auth.dto.KakaoCallbackRequest;
 import com.deoham.auth.dto.KakaoCallbackResponse;
 import com.deoham.auth.dto.RefreshTokenRequest;
@@ -7,13 +8,6 @@ import com.deoham.auth.dto.TokenResponse;
 import com.deoham.auth.service.AuthService;
 import com.deoham.global.metrics.MetricEndpoint;
 import com.deoham.global.response.ApiResponse;
-import com.deoham.global.security.AuthenticationUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,30 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
-@Tag(name = "Auth", description = "인증 API")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
 
 	private final AuthService authService;
 
+	@Override
 	@GetMapping("/kakao")
-	@Operation(
-			summary = "카카오 로그인 시작",
-			description = "카카오 OAuth 인가 URL로 302 리다이렉트합니다. " +
-					"redirect_uri는 서버의 KAKAO_REDIRECT_URI 환경변수 값을 사용합니다. " +
-					"서버가 OAuth state를 생성하고 저장하므로 이 엔드포인트를 통해 로그인을 시작해야 합니다."
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "302",
-					description = "카카오 OAuth 인가 URL로 리다이렉트",
-					headers = @Header(
-							name = "Location",
-							description = "https://kauth.kakao.com/oauth/authorize?client_id={KAKAO_REST_API_KEY}&redirect_uri={KAKAO_REDIRECT_URI}&response_type=code",
-							schema = @Schema(type = "string")
-					)
-			)
-	})
 	@MetricEndpoint("auth.kakao.redirect")
 	public ResponseEntity<Void> kakaoAuthRedirect() {
 		return ResponseEntity.status(HttpStatus.FOUND)
@@ -58,31 +35,8 @@ public class AuthController {
 				.build();
 	}
 
+	@Override
 	@PostMapping("/kakao/callback")
-	@Operation(
-			summary = "카카오 로그인 콜백",
-			description = "프론트엔드가 카카오로부터 받은 인가 코드를 백엔드로 전달합니다. " +
-					"요청에는 카카오 리다이렉트 쿼리의 code와 state를 모두 포함해야 합니다. " +
-					"백엔드가 카카오 API와 직접 토큰 교환 및 유저 정보 조회를 수행하고, " +
-					"우리 서버의 JWT를 발급합니다. 최초 로그인이면 isNewUser=true를 반환합니다."
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "200",
-					description = "로그인/회원가입 성공, JWT 반환",
-					content = @Content(schema = @Schema(implementation = KakaoCallbackResponse.class))
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "400",
-					description = "입력값 검증 실패",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "유효하지 않은 인가 코드",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("auth.kakao.callback")
 	public ResponseEntity<KakaoCallbackResponse> kakaoCallback(
 			@RequestBody @Valid KakaoCallbackRequest request
@@ -90,25 +44,8 @@ public class AuthController {
 		return ResponseEntity.ok(authService.kakaoLogin(request.code(), request.state()));
 	}
 
+	@Override
 	@PostMapping("/refresh")
-	@Operation(
-			summary = "액세스 토큰 갱신",
-			description = "만료된 액세스 토큰을 리프레시 토큰으로 갱신합니다. " +
-					"갱신 시 리프레시 토큰도 함께 회전(rotation)되어 새 리프레시 토큰이 발급되며, " +
-					"기존 리프레시 토큰은 더 이상 사용할 수 없습니다. 응답의 refreshToken을 반드시 교체 저장하세요."
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "200",
-					description = "토큰 갱신 성공",
-					content = @Content(schema = @Schema(implementation = TokenResponse.class))
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "유효하지 않거나 만료된 리프레시 토큰",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("auth.refresh")
 	public ResponseEntity<ApiResponse<TokenResponse>> refresh(
 			@RequestBody @Valid RefreshTokenRequest request
@@ -116,20 +53,8 @@ public class AuthController {
 		return ResponseEntity.ok(ApiResponse.ok(authService.refresh(request.refreshToken())));
 	}
 
+	@Override
 	@PostMapping("/logout")
-	@Operation(summary = "로그아웃", description = "현재 사용자에게 저장된 리프레시 토큰을 모두 폐기합니다. " +
-			"발급된 액세스 토큰은 만료 시까지 유효하므로, 클라이언트에서도 저장된 토큰을 삭제해야 합니다.")
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "200",
-					description = "로그아웃 성공 (data: null)"
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "인증 필요",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("auth.logout")
 	public ResponseEntity<ApiResponse<Void>> logout(Authentication authentication) {
 		authService.logout(authentication);

--- a/src/main/java/com/deoham/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/deoham/auth/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,100 @@
+package com.deoham.auth.controller.docs;
+
+import com.deoham.auth.dto.KakaoCallbackRequest;
+import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.dto.RefreshTokenRequest;
+import com.deoham.auth.dto.TokenResponse;
+import com.deoham.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "Auth", description = "인증 API")
+public interface AuthControllerDocs {
+
+	@Operation(
+			summary = "카카오 로그인 시작",
+			description = "카카오 OAuth 인가 URL로 302 리다이렉트합니다. " +
+					"redirect_uri는 서버의 KAKAO_REDIRECT_URI 환경변수 값을 사용합니다. " +
+					"서버가 OAuth state를 생성하고 저장하므로 이 엔드포인트를 통해 로그인을 시작해야 합니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "302",
+					description = "카카오 OAuth 인가 URL로 리다이렉트",
+					headers = @Header(
+							name = "Location",
+							description = "https://kauth.kakao.com/oauth/authorize?client_id={KAKAO_REST_API_KEY}&redirect_uri={KAKAO_REDIRECT_URI}&response_type=code",
+							schema = @Schema(type = "string")
+					)
+			)
+	})
+	ResponseEntity<Void> kakaoAuthRedirect();
+
+	@Operation(
+			summary = "카카오 로그인 콜백",
+			description = "프론트엔드가 카카오로부터 받은 인가 코드를 백엔드로 전달합니다. " +
+					"요청에는 카카오 리다이렉트 쿼리의 code와 state를 모두 포함해야 합니다. " +
+					"백엔드가 카카오 API와 직접 토큰 교환 및 유저 정보 조회를 수행하고, " +
+					"우리 서버의 JWT를 발급합니다. 최초 로그인이면 isNewUser=true를 반환합니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "로그인/회원가입 성공, JWT 반환",
+					content = @Content(schema = @Schema(implementation = KakaoCallbackResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "400",
+					description = "입력값 검증 실패",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "유효하지 않은 인가 코드",
+					content = @Content
+			)
+	})
+	ResponseEntity<KakaoCallbackResponse> kakaoCallback(@Valid KakaoCallbackRequest request);
+
+	@Operation(
+			summary = "액세스 토큰 갱신",
+			description = "만료된 액세스 토큰을 리프레시 토큰으로 갱신합니다. " +
+					"갱신 시 리프레시 토큰도 함께 회전(rotation)되어 새 리프레시 토큰이 발급되며, " +
+					"기존 리프레시 토큰은 더 이상 사용할 수 없습니다. 응답의 refreshToken을 반드시 교체 저장하세요."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "토큰 갱신 성공",
+					content = @Content(schema = @Schema(implementation = TokenResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "유효하지 않거나 만료된 리프레시 토큰",
+					content = @Content
+			)
+	})
+	ResponseEntity<ApiResponse<TokenResponse>> refresh(@Valid RefreshTokenRequest request);
+
+	@Operation(summary = "로그아웃", description = "현재 사용자에게 저장된 리프레시 토큰을 모두 폐기합니다. " +
+			"발급된 액세스 토큰은 만료 시까지 유효하므로, 클라이언트에서도 저장된 토큰을 삭제해야 합니다.")
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "로그아웃 성공 (data: null)"
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			)
+	})
+	ResponseEntity<ApiResponse<Void>> logout(Authentication authentication);
+}

--- a/src/main/java/com/deoham/card/controller/CardController.java
+++ b/src/main/java/com/deoham/card/controller/CardController.java
@@ -12,9 +12,6 @@ import com.deoham.card.service.CardWriteService;
 import com.deoham.global.metrics.MetricEndpoint;
 import com.deoham.global.response.ApiResponse;
 import com.deoham.global.security.AuthenticationUtils;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -44,9 +41,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.create")
     @PostMapping("/cards")
     public ResponseEntity<CardDetailResponse> createCard(
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "Card create request", required = true,
-                    content = @Content(schema = @Schema(implementation = CreateCardRequest.class)))
             @Valid @RequestBody CreateCardRequest request
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -59,7 +53,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     public ResponseEntity<PaginatedCardListResponse> getNearbyCards(
             @RequestParam @NotNull Double latitude,
             @RequestParam @NotNull Double longitude,
-            @Parameter(description = "Optional pagination cursor 선택 항목", example = "NTAuNXxhMWIyYzNkNGU1ZjY=")
             @RequestParam(required = false) String cursor
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -85,7 +78,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.cancel")
     @PatchMapping("/cards/{cardId}/cancel")
     public ResponseEntity<Void> cancelCard(
-            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -97,7 +89,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.complete")
     @PatchMapping("/cards/{cardId}/complete")
     public ResponseEntity<Void> completeCard(
-            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -109,7 +100,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.retry")
     @PatchMapping("/cards/{cardId}/retry")
     public ResponseEntity<Void> retryCard(
-            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -121,7 +111,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.apply.submit")
     @PostMapping("/cards/{cardId}/applies")
     public ResponseEntity<CardApplySummaryResponse> submitApply(
-            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();
@@ -132,7 +121,6 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
     @MetricEndpoint("card.apply.list")
     @GetMapping("/cards/{cardId}/applies")
     public ResponseEntity<List<CardApplySummaryResponse>> getApplies(
-            @Parameter(description = "Card ID", required = true)
             @PathVariable UUID cardId
     ) {
         UUID userId = AuthenticationUtils.requiredUserId();

--- a/src/main/java/com/deoham/card/controller/docs/CardControllerDocs.java
+++ b/src/main/java/com/deoham/card/controller/docs/CardControllerDocs.java
@@ -54,7 +54,7 @@ public interface CardControllerDocs {
     ResponseEntity<PaginatedCardListResponse> getNearbyCards(
             @Parameter(description = "Latitude", required = true, example = "37.5326") @NotNull Double latitude,
             @Parameter(description = "Longitude", required = true, example = "126.9903") @NotNull Double longitude,
-            @Parameter(description = "Optional pagination cursor", example = "NTAuNXxhMWIyYzNkNGU1ZjY=") String cursor);
+            @Parameter(description = "Optional pagination cursor 선택 항목", example = "NTAuNXxhMWIyYzNkNGU1ZjY=") String cursor);
 
     @Operation(
             summary = "내 활성 카드 조회",

--- a/src/main/java/com/deoham/user/controller/UserController.java
+++ b/src/main/java/com/deoham/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.deoham.user.controller;
 
+import com.deoham.user.controller.docs.UserControllerDocs;
 import com.deoham.user.dto.ProfileResponse;
 import com.deoham.user.dto.ProfileUpdateRequest;
 import com.deoham.global.exception.BusinessException;
@@ -9,14 +10,6 @@ import com.deoham.global.security.AuthenticationUtils;
 import com.deoham.user.service.UserReadService;
 import com.deoham.user.service.UserWriteService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.SchemaProperty;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,115 +20,34 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/user")
-@Tag(name = "User", description = "사용자 API")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserControllerDocs {
 
 	private final UserReadService userReadService;
 	private final UserWriteService userWriteService;
 	private final ObjectMapper objectMapper;
 
+	@Override
 	@GetMapping("/profile")
-	@Operation(
-			summary = "프로필 조회",
-			description = "현재 로그인한 사용자의 프로필 정보를 조회합니다. " +
-					"닉네임, 프로필 이미지 URL, 도움을 받은 횟수, 도움을 준 횟수를 반환합니다."
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "200",
-					description = "프로필 조회 성공",
-					content = @Content(schema = @Schema(implementation = ProfileResponse.class))
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "인증 필요",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "404",
-					description = "사용자 정보를 찾을 수 없음",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("user.profile.get")
 	public ResponseEntity<ProfileResponse> getProfile(Authentication authentication) {
 		var profile = userReadService.getProfile(AuthenticationUtils.requiredUserId(authentication));
 		return ResponseEntity.ok(profile);
 	}
 
+	@Override
 	@PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Operation(
-			summary = "프로필 생성(최초 설정)",
-			description = "회원가입(카카오 최초 로그인) 직후 현재 로그인한 사용자의 프로필(닉네임, 프로필 이미지)을 설정합니다. " +
-					"유저 레코드 자체는 카카오 로그인 시점에 이미 생성되어 있으며, 이 API는 초기 프로필 정보를 채웁니다. " +
-					"닉네임과 프로필 이미지 중 최소 하나는 필수입니다. " +
-					"multipart/form-data로 전송하며, S3에 저장됩니다.\n\n" +
-					"**Request Body 예시:**\n" +
-					"- request (JSON part): `{\"nickname\":\"홍길동\"}`\n" +
-					"- profileImage (파일): image.jpg"
-	)
-	@RequestBody(
-		description = "multipart/form-data 형식. " +
-			"- request: ProfileUpdateRequest JSON (닉네임 선택사항) " +
-			"- profileImage: 이미지 파일 (선택사항)",
-			content = @Content(
-				mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-				schemaProperties = {
-						@SchemaProperty(
-								name = "request",
-								schema = @Schema(implementation = ProfileUpdateRequest.class)
-						),
-						@SchemaProperty(
-								name = "profileImage",
-								schema = @Schema(type = "string", format = "binary")
-						)
-				}
-		)
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "201",
-					description = "프로필 생성 성공",
-					content = @Content(schema = @Schema(implementation = ProfileResponse.class))
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "400",
-					description = "입력값 검증 실패",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "인증 필요",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "404",
-					description = "사용자 정보를 찾을 수 없음",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "409",
-					description = "닉네임 중복",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("user.profile.create")
 	public ResponseEntity<ProfileResponse> createProfile(
 			Authentication authentication,
-			@RequestPart(name = "request", required = false)
-			@Schema(example = "{\"nickname\": \"홍길동\"}")
-			String requestJson,
-			@RequestPart(name = "profileImage", required = false)
-			@Schema(example = "image.jpg")
-			MultipartFile profileImage
+			@RequestPart(name = "request", required = false) String requestJson,
+			@RequestPart(name = "profileImage", required = false) MultipartFile profileImage
 	) throws Exception {
 		ProfileUpdateRequest request = null;
 		if (requestJson != null && !requestJson.isBlank()) {
@@ -155,71 +67,13 @@ public class UserController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(ProfileResponse.from(updatedUser));
 	}
 
+	@Override
 	@PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Operation(
-			summary = "프로필 업데이트",
-			description = "현재 로그인한 사용자의 닉네임과 프로필 이미지를 업데이트합니다. " +
-					"닉네임과 프로필 이미지 중 최소 하나는 필수입니다. " +
-					"multipart/form-data로 전송하며, S3에 저장됩니다. " +
-					"성공 시 응답 본문 없이 204(No Content)를 반환합니다.\n\n" +
-					"**Request Body 예시:**\n" +
-					"- request (JSON part): `{\"nickname\":\"새로운닉네임\"}`\n" +
-					"- profileImage (파일): image.jpg"
-	)
-	@RequestBody(
-			description = "multipart/form-data 형식. " +
-					"- request: ProfileUpdateRequest JSON (닉네임 선택사항) " +
-					"- profileImage: 이미지 파일 (선택사항)",
-			content = @Content(
-					mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-					schemaProperties = {
-							@SchemaProperty(
-									name = "request",
-									schema = @Schema(implementation = ProfileUpdateRequest.class)
-							),
-							@SchemaProperty(
-									name = "profileImage",
-									schema = @Schema(type = "string", format = "binary")
-							)
-					}
-			)
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "204",
-					description = "프로필 업데이트 성공",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "400",
-					description = "입력값 검증 실패",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "인증 필요",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "404",
-					description = "사용자 정보를 찾을 수 없음",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "409",
-					description = "닉네임 중복",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("user.profile.update")
 	public ResponseEntity<Void> updateProfile(
 			Authentication authentication,
-			@RequestPart(name = "request", required = false)
-			@Schema(example = "{\"nickname\": \"새로운닉네임\"}")
-			String requestJson,
-			@RequestPart(name = "profileImage", required = false)
-			@Schema(example = "new-image.jpg")
-			MultipartFile profileImage
+			@RequestPart(name = "request", required = false) String requestJson,
+			@RequestPart(name = "profileImage", required = false) MultipartFile profileImage
 	) throws Exception {
 		ProfileUpdateRequest request = null;
 		if (requestJson != null && !requestJson.isBlank()) {
@@ -239,28 +93,8 @@ public class UserController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@Override
 	@DeleteMapping
-	@Operation(
-			summary = "회원 탈퇴",
-			description = "현재 로그인한 사용자의 계정을 탈퇴합니다. (soft delete)"
-	)
-	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "204",
-					description = "회원 탈퇴 성공",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "401",
-					description = "인증 필요",
-					content = @Content
-			),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(
-					responseCode = "404",
-					description = "사용자 정보를 찾을 수 없음",
-					content = @Content
-			)
-	})
 	@MetricEndpoint("user.delete")
 	public ResponseEntity<Void> deleteUser(Authentication authentication) {
 		userWriteService.deleteUser(AuthenticationUtils.requiredUserId(authentication));

--- a/src/main/java/com/deoham/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/deoham/user/controller/docs/UserControllerDocs.java
@@ -1,0 +1,187 @@
+package com.deoham.user.controller.docs;
+
+import com.deoham.user.dto.ProfileResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "User", description = "사용자 API")
+public interface UserControllerDocs {
+
+	@Operation(
+			summary = "프로필 조회",
+			description = "현재 로그인한 사용자의 프로필 정보를 조회합니다. " +
+					"닉네임, 프로필 이미지 URL, 도움을 받은 횟수, 도움을 준 횟수를 반환합니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "프로필 조회 성공",
+					content = @Content(schema = @Schema(implementation = ProfileResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			)
+	})
+	ResponseEntity<ProfileResponse> getProfile(Authentication authentication);
+
+	@Operation(
+			summary = "프로필 생성(최초 설정)",
+			description = "회원가입(카카오 최초 로그인) 직후 현재 로그인한 사용자의 프로필(닉네임, 프로필 이미지)을 설정합니다. " +
+					"유저 레코드 자체는 카카오 로그인 시점에 이미 생성되어 있으며, 이 API는 초기 프로필 정보를 채웁니다. " +
+					"닉네임과 프로필 이미지 중 최소 하나는 필수입니다. " +
+					"multipart/form-data로 전송하며, S3에 저장됩니다.\n\n" +
+					"**Request Body 예시:**\n" +
+					"- request (JSON part): `{\"nickname\":\"홍길동\"}`\n" +
+					"- profileImage (파일): image.jpg"
+	)
+	@RequestBody(
+		description = "multipart/form-data 형식. " +
+			"- request: ProfileUpdateRequest JSON (닉네임 선택사항) " +
+			"- profileImage: 이미지 파일 (선택사항)",
+			content = @Content(
+				mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+				schemaProperties = {
+						@SchemaProperty(
+								name = "request",
+								schema = @Schema(implementation = com.deoham.user.dto.ProfileUpdateRequest.class)
+						),
+						@SchemaProperty(
+								name = "profileImage",
+								schema = @Schema(type = "string", format = "binary")
+						)
+				}
+		)
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "201",
+					description = "프로필 생성 성공",
+					content = @Content(schema = @Schema(implementation = ProfileResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "400",
+					description = "입력값 검증 실패",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "409",
+					description = "닉네임 중복",
+					content = @Content
+			)
+	})
+	ResponseEntity<ProfileResponse> createProfile(
+			Authentication authentication,
+			@Schema(example = "{\"nickname\": \"홍길동\"}") String requestJson,
+			@Schema(example = "image.jpg") MultipartFile profileImage
+	) throws Exception;
+
+	@Operation(
+			summary = "프로필 업데이트",
+			description = "현재 로그인한 사용자의 닉네임과 프로필 이미지를 업데이트합니다. " +
+					"닉네임과 프로필 이미지 중 최소 하나는 필수입니다. " +
+					"multipart/form-data로 전송하며, S3에 저장됩니다. " +
+					"성공 시 응답 본문 없이 204(No Content)를 반환합니다.\n\n" +
+					"**Request Body 예시:**\n" +
+					"- request (JSON part): `{\"nickname\":\"새로운닉네임\"}`\n" +
+					"- profileImage (파일): image.jpg"
+	)
+	@RequestBody(
+			description = "multipart/form-data 형식. " +
+					"- request: ProfileUpdateRequest JSON (닉네임 선택사항) " +
+					"- profileImage: 이미지 파일 (선택사항)",
+			content = @Content(
+					mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+					schemaProperties = {
+							@SchemaProperty(
+									name = "request",
+									schema = @Schema(implementation = com.deoham.user.dto.ProfileUpdateRequest.class)
+							),
+							@SchemaProperty(
+									name = "profileImage",
+									schema = @Schema(type = "string", format = "binary")
+							)
+					}
+			)
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "204",
+					description = "프로필 업데이트 성공",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "400",
+					description = "입력값 검증 실패",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "409",
+					description = "닉네임 중복",
+					content = @Content
+			)
+	})
+	ResponseEntity<Void> updateProfile(
+			Authentication authentication,
+			@Schema(example = "{\"nickname\": \"새로운닉네임\"}") String requestJson,
+			@Schema(example = "new-image.jpg") MultipartFile profileImage
+	) throws Exception;
+
+	@Operation(
+			summary = "회원 탈퇴",
+			description = "현재 로그인한 사용자의 계정을 탈퇴합니다. (soft delete)"
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "204",
+					description = "회원 탈퇴 성공",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "401",
+					description = "인증 필요",
+					content = @Content
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "사용자 정보를 찾을 수 없음",
+					content = @Content
+			)
+	})
+	ResponseEntity<Void> deleteUser(Authentication authentication);
+}


### PR DESCRIPTION
## Summary
- UserController에 섞여 있던 Swagger(@Operation/@ApiResponses 등) 애노테이션을 UserControllerDocs 인터페이스로 분리
- AuthController도 동일한 패턴으로 AuthControllerDocs 인터페이스 분리 (기존에 분리 안 되어 있던 유일한 컨트롤러)
- CardController에 남아있던 중복 Swagger 파라미터 애노테이션(@Parameter, @RequestBody) 정리 - 이미 CardControllerDocs/CardApplyControllerDocs에 동일 내용이 있어 컨트롤러 쪽 중복 제거

## Test plan
- [x] `./gradlew compileJava` 통과 확인
- [ ] Swagger UI(`/swagger-ui.html`)에서 User/Auth/Card API 문서가 기존과 동일하게 보이는지 확인

https://claude.ai/code/session_01KMTEnW4MHxyPYSbNuso8J6