### PR TITLE
FIX: 배포 CI에 DEEPL_API_KEY 주입 추가 (번역 403 해결)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,11 @@ jobs:
           KAKAO_REDIRECT_URI=${{ vars.KAKAO_REDIRECT_URI }}
           KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
 
-          # Gemini — 채팅 메시지 번역 프로바이더
+          # Gemini — (구) 채팅 메시지 번역 프로바이더, DeepL 전환 후 미사용이나 @NotBlank 바인딩 유지용
           GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+
+          # DeepL — 채팅 메시지 번역 프로바이더 (현재 @Primary)
+          DEEPL_API_KEY=${{ secrets.DEEPL_API_KEY }}
 
           # FCM — Java 바인딩 없음, 구현 완료 후 활성화
           # FCM_KEY_PATH=/app/secrets/fcm-service-account.json
@@ -145,7 +148,8 @@ jobs:
           echo "=== Checking required environment variables ==="
           MISSING_VARS=""
           for var in JWT_SECRET AWS_S3_REGION AWS_S3_BUCKET AWS_S3_PRESIGNED_TTL \
-                      KAKAO_REST_API_KEY KAKAO_CLIENT_SECRET GRAFANA_ADMIN_USER GRAFANA_ADMIN_PASSWORD; do
+                      KAKAO_REST_API_KEY KAKAO_CLIENT_SECRET GEMINI_API_KEY DEEPL_API_KEY \
+                      GRAFANA_ADMIN_USER GRAFANA_ADMIN_PASSWORD; do
             if grep -q "^$var=$" .env; then
               echo "❌ ERROR: $var is empty"
               MISSING_VARS="$MISSING_VARS $var"


### PR DESCRIPTION
## 문제
DeepL 번역 프로바이더로 전환됐지만, 배포 워크플로(`ci.yml`)의 `.env` 생성 단계에 **`DEEPL_API_KEY`가 누락**돼 있었다. 그 결과 EC2 서버가 유효하지 않은 키로 DeepL API를 호출 → **403 Forbidden**으로 번역 실패.

- `GitHub secret`을 등록/수정해도 CI가 `.env`에 안 써서 서버에 반영되지 않음
- 서버 로그: `DeepL translation request failed. Status: 403 FORBIDDEN`
- 키 자체는 정상 확인됨 (무료 엔드포인트 200, 쿼터 여유)

## 변경
- `.env` 생성부에 `DEEPL_API_KEY=${{ secrets.DEEPL_API_KEY }}` 추가
- Validate 단계 필수 변수 목록에 `GEMINI_API_KEY`, `DEEPL_API_KEY` 추가
  - 둘 다 `@NotBlank` 바인딩이라 비어 있으면 앱 부팅 실패 → 배포 전 사전 차단

## 배포 전 확인
- [ ] GitHub `Settings > Secrets`에 **`DEEPL_API_KEY`** secret 등록 여부 (없으면 이 PR 머지 후 배포가 validate에서 중단됨)

## 머지 시 효과
develop 배포가 돌면서 서버 `.env`에 올바른 DeepL 키가 주입 → 컨테이너 재생성 → **서버 403 자동 해결**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)