### PR TITLE
FIX: DeepL target_lang 정규화 (지역 로케일 ko-KR 400 해결)

### DIFF
--- a/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
@@ -4,6 +4,7 @@ import com.deoham.global.config.DeepLProperties;
 import com.deoham.global.exception.BusinessException;
 import com.deoham.global.exception.ErrorCode;
 import java.util.Locale;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
@@ -21,6 +22,13 @@ public class DeepLTranslationProvider implements TranslationProvider {
 
 	private static final String PROVIDER_NAME = "DEEPL";
 
+	/**
+	 * DeepL 이 target_lang 으로 허용하는 지역 변형 코드. 이 집합에 없는 지역 코드는
+	 * 기본 언어로 축약한다. (예: KO/JA 는 지역 변형을 지원하지 않아 KO-KR → KO 로 처리)
+	 */
+	private static final Set<String> DEEPL_REGIONAL_TARGETS =
+			Set.of("EN-GB", "EN-US", "PT-BR", "PT-PT", "ZH-HANS", "ZH-HANT", "ES-419");
+
 	private final RestClient restClient;
 	private final DeepLProperties properties;
 
@@ -31,8 +39,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
 
 	@Override
 	public TranslationResult translate(String text, String targetLanguage) {
-		// DeepL 은 target_lang 에 대문자 언어 코드(EN, KO, JA ...)를 요구한다.
-		String targetLang = targetLanguage.toUpperCase(Locale.ROOT);
+		String targetLang = normalizeTargetLang(targetLanguage);
 
 		DeepLTranslateResponse response;
 		try {
@@ -44,7 +51,13 @@ public class DeepLTranslationProvider implements TranslationProvider {
 					.retrieve()
 					.body(DeepLTranslateResponse.class);
 		} catch (RestClientResponseException e) {
-			log.warn("DeepL translation request failed. Status: {}, Response: {}", e.getStatusCode(), e.getResponseBodyAsString());
+			log.warn("DeepL translation request failed. targetLang={} (원본 {}), Status: {}, Response: {}",
+					targetLang, targetLanguage, e.getStatusCode(), e.getResponseBodyAsString());
+			// 400 = target_lang 미지원 등 클라이언트 입력 문제 → 인증/서버 오류(401/403/456/5xx)와 구분
+			if (e.getStatusCode().value() == 400) {
+				throw new BusinessException(ErrorCode.INVALID_REQUEST,
+						"지원하지 않는 번역 대상 언어입니다: " + targetLanguage);
+			}
 			throw new BusinessException(ErrorCode.INTERNAL_ERROR, "번역 요청 처리 중 오류가 발생했습니다.");
 		}
 
@@ -55,6 +68,20 @@ public class DeepLTranslationProvider implements TranslationProvider {
 		}
 
 		return new TranslationResult(translatedText.trim(), PROVIDER_NAME);
+	}
+
+	/**
+	 * 클라이언트가 보낸 언어 코드를 DeepL target_lang 형식으로 정규화한다.
+	 * 대문자화 후, DeepL 이 지원하는 지역 변형(EN-US 등)은 그대로 두고
+	 * 그 외 지역 서브태그는 제거한다. (예: ko-KR → KO, en-US → EN-US, zh_Hans → ZH-HANS)
+	 */
+	private static String normalizeTargetLang(String targetLanguage) {
+		String code = targetLanguage.trim().toUpperCase(Locale.ROOT).replace('_', '-');
+		if (DEEPL_REGIONAL_TARGETS.contains(code)) {
+			return code;
+		}
+		int dash = code.indexOf('-');
+		return dash > 0 ? code.substring(0, dash) : code;
 	}
 
 	@Override

--- a/src/test/java/com/deoham/chat/translation/DeepLTranslationProviderTest.java
+++ b/src/test/java/com/deoham/chat/translation/DeepLTranslationProviderTest.java
@@ -6,6 +6,7 @@ import com.deoham.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
@@ -62,6 +64,48 @@ class DeepLTranslationProviderTest {
         assertThat(result.translatedText()).isEqualTo("Hello");
         assertThat(result.modelVersion()).isEqualTo("DEEPL");
         server.verify();
+    }
+
+    @Test
+    void translate_stripsUnsupportedRegionSubtag_koKR_toKO() {
+        server.expect(requestTo(EXPECTED_URI))
+                .andExpect(jsonPath("$.target_lang").value("KO"))
+                .andRespond(withSuccess("""
+                        {"translations": [{"detected_source_language": "EN", "text": "안녕"}]}
+                        """, MediaType.APPLICATION_JSON));
+
+        DeepLTranslationProvider provider = new DeepLTranslationProvider(client, PROPERTIES);
+
+        assertThat(provider.translate("hello", "ko-KR").translatedText()).isEqualTo("안녕");
+        server.verify();
+    }
+
+    @Test
+    void translate_keepsSupportedRegionalVariant_enUS() {
+        server.expect(requestTo(EXPECTED_URI))
+                .andExpect(jsonPath("$.target_lang").value("EN-US"))
+                .andRespond(withSuccess("""
+                        {"translations": [{"detected_source_language": "KO", "text": "Hi"}]}
+                        """, MediaType.APPLICATION_JSON));
+
+        DeepLTranslationProvider provider = new DeepLTranslationProvider(client, PROPERTIES);
+
+        assertThat(provider.translate("안녕", "en-US").translatedText()).isEqualTo("Hi");
+        server.verify();
+    }
+
+    @Test
+    void translate_throwsInvalidRequest_onDeepL400() {
+        server.expect(requestTo(containsString("/v2/translate")))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST)
+                        .body("{\"message\":\"Bad request. Reason: Value for 'target_lang' not supported.\"}")
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        DeepLTranslationProvider provider = new DeepLTranslationProvider(client, PROPERTIES);
+
+        assertThatThrownBy(() -> provider.translate("안녕하세요", "xx"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST));
     }
 
     @Test


### PR DESCRIPTION
## 문제
403(키) 해결 후, 클라이언트가 `ko-KR` 같은 **지역 포함 로케일**을 보내면 `.toUpperCase()` 결과 `KO-KR`을 DeepL이 거부:
```
Status: 400 BAD_REQUEST, {"message":"Bad request. Reason: Value for 'target_lang' not supported."}
```
DeepL은 한국어/일본어는 지역 없는 `KO`/`JA`만 받고, 영어/중국어만 지역 변형(`EN-US`, `ZH-HANS`)을 허용함 (curl로 확인).

## 변경
- `normalizeTargetLang()` 추가 — DeepL 지원 지역 변형(EN-GB/EN-US/PT-BR/PT-PT/ZH-HANS/ZH-HANT/ES-419)은 유지, 그 외 지역 서브태그 제거 (`ko-KR`→`KO`, `en-US`→`EN-US`, `zh_Hans`→`ZH-HANS`)
- DeepL **400 → `INVALID_REQUEST`** 매핑 (401/403/456/5xx는 기존대로 `INTERNAL_ERROR`), 실패 로그에 `target_lang` 노출
- 테스트 3건 추가 (총 8건, 전부 통과)

## 머지 시 효과
develop 배포 → 컨테이너 재생성 → 지역 로케일 번역 정상 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)