### PR TITLE
FIX: 카카오 재로그인 시 닉네임 설정(온보딩) 건너뛰는 문제 해결

### DIFF
--- a/src/main/java/com/deoham/auth/service/AuthService.java
+++ b/src/main/java/com/deoham/auth/service/AuthService.java
@@ -80,9 +80,8 @@ public class AuthService {
 				.findByProviderAndProviderUid(OauthProvider.KAKAO, kakaoId)
 				.orElse(null);
 
-		boolean isNewUser = socialAccount == null;
 		User user;
-		if (isNewUser) {
+		if (socialAccount == null) {
 			user = userRepository.save(User.builder()
 					.nickname(generateDefaultNickname(kakaoId))
 					.gender(parseGender(userInfo.gender()))
@@ -111,12 +110,17 @@ public class AuthService {
 				refreshToken,
 				Instant.now().plusSeconds(jwtProperties.refreshTokenExpirySeconds()));
 
+		// "신규 사용자"는 레코드가 방금 생성됐는지가 아니라 온보딩(닉네임 설정)을 마쳤는지로 판단한다.
+		// 콜백에서 User/UserSocialAccount는 즉시 저장되므로, 닉네임 설정 없이 이탈 후 재로그인해도
+		// 온보딩이 미완료면 계속 신규 사용자로 안내한다.
+		boolean needsOnboarding = !user.isOnboardingCompleted();
+
 		return new KakaoCallbackResponse(
 				accessToken,
 				refreshToken,
 				"Bearer",
 				jwtProperties.accessTokenExpirySeconds(),
-				isNewUser);
+				needsOnboarding);
 	}
 
 	@Transactional

--- a/src/main/java/com/deoham/user/entity/User.java
+++ b/src/main/java/com/deoham/user/entity/User.java
@@ -79,6 +79,9 @@ public class User extends BaseEntity {
     @Column(name = "has_seen_card_view_onboarding", nullable = false)
     private boolean hasSeenCardViewOnboarding = false;
 
+    @Column(name = "onboarding_completed", nullable = false)
+    private boolean onboardingCompleted = false;
+
     @Builder
     private User(String firebaseUid, String nickname, String profileImageUrl, GenderType gender, Integer age) {
         this.firebaseUid = firebaseUid != null ? firebaseUid : UUID.randomUUID().toString();
@@ -143,6 +146,10 @@ public class User extends BaseEntity {
 
     public void markCardViewOnboardingSeen() {
         this.hasSeenCardViewOnboarding = true;
+    }
+
+    public void completeOnboarding() {
+        this.onboardingCompleted = true;
     }
 
     public void clearProfileImage() {

--- a/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
@@ -73,6 +73,9 @@ public class UserWriteServiceImpl implements UserWriteService {
         }
 
         user.updateProfile(nickname, profileImageUrl);
+        if (nickname != null) {
+            user.completeOnboarding();
+        }
         return userRepository.save(user);
     }
 

--- a/src/main/resources/db/migration/V28__add_onboarding_completed.sql
+++ b/src/main/resources/db/migration/V28__add_onboarding_completed.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users ADD COLUMN onboarding_completed BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- 기존 사용자는 이미 닉네임을 설정하고 앱을 사용 중이므로 온보딩 완료로 간주.
+-- 단, 카카오 기본 닉네임(kakao_<id>)에 머물러 있는 사용자는 미완료로 남긴다.
+UPDATE users SET onboarding_completed = TRUE WHERE nickname NOT LIKE 'kakao\_%';

--- a/src/test/java/com/deoham/auth/service/AuthServiceOnboardingTest.java
+++ b/src/test/java/com/deoham/auth/service/AuthServiceOnboardingTest.java
@@ -1,0 +1,135 @@
+package com.deoham.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.deoham.auth.client.KakaoOAuthClient;
+import com.deoham.auth.client.KakaoTokenResponse;
+import com.deoham.auth.client.KakaoUserInfo;
+import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.entity.OAuthState;
+import com.deoham.auth.repository.OAuthStateRepository;
+import com.deoham.global.config.KakaoOAuthProperties;
+import com.deoham.global.security.JwtProperties;
+import com.deoham.global.security.JwtTokenProvider;
+import com.deoham.user.entity.GenderType;
+import com.deoham.user.entity.OauthProvider;
+import com.deoham.user.entity.User;
+import com.deoham.user.entity.UserSocialAccount;
+import com.deoham.user.repository.UserRepository;
+import com.deoham.user.repository.UserSocialAccountRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 카카오 로그인 온보딩 신호 테스트")
+class AuthServiceOnboardingTest {
+
+	private static final String CODE = "auth-code";
+	private static final String STATE = "state-value";
+	private static final Long KAKAO_ID = 123456789L;
+
+	@Mock
+	private KakaoOAuthClient kakaoOAuthClient;
+	@Mock
+	private KakaoOAuthProperties kakaoOAuthProperties;
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	@Mock
+	private JwtProperties jwtProperties;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private UserSocialAccountRepository userSocialAccountRepository;
+	@Mock
+	private OAuthStateRepository oauthStateRepository;
+
+	private AuthService authService;
+
+	@BeforeEach
+	void setUp() {
+		authService = new AuthService(
+				kakaoOAuthClient,
+				kakaoOAuthProperties,
+				jwtTokenProvider,
+				jwtProperties,
+				userRepository,
+				userSocialAccountRepository,
+				oauthStateRepository);
+
+		when(oauthStateRepository.findByStateAndProvider(STATE, OauthProvider.KAKAO))
+				.thenReturn(Optional.of(new OAuthState(
+						STATE, OauthProvider.KAKAO, Instant.now().plusSeconds(300))));
+		when(kakaoOAuthClient.exchangeCode(CODE))
+				.thenReturn(new KakaoTokenResponse("bearer", "kakao-access", 3600, "kakao-refresh", 3600));
+		when(kakaoOAuthClient.getUserInfo("kakao-access"))
+				.thenReturn(new KakaoUserInfo(KAKAO_ID,
+						new KakaoUserInfo.KakaoAccount("user@example.com", true, "male", "1995")));
+		when(jwtTokenProvider.generateAccessToken(any(), any(), any())).thenReturn("access-jwt");
+		when(jwtTokenProvider.generateRefreshToken(any())).thenReturn("refresh-jwt");
+	}
+
+	@Test
+	@DisplayName("최초 로그인(소셜 계정 없음)이면 isNewUser=true")
+	void firstLogin_returnsNewUser() {
+		when(userSocialAccountRepository.findByProviderAndProviderUid(OauthProvider.KAKAO, KAKAO_ID.toString()))
+				.thenReturn(Optional.empty());
+		when(userRepository.existsByNickname(any())).thenReturn(false);
+		when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(userSocialAccountRepository.save(any(UserSocialAccount.class)))
+				.thenAnswer(inv -> inv.getArgument(0));
+
+		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+
+		assertThat(response.isNewUser()).isTrue();
+	}
+
+	@Test
+	@DisplayName("재로그인이지만 온보딩 미완료면 isNewUser=true (닉네임 미설정 후 이탈 케이스)")
+	void reLogin_notOnboarded_returnsNewUser() {
+		User notOnboarded = User.builder()
+				.nickname("kakao_" + KAKAO_ID)
+				.gender(GenderType.MALE)
+				.age(30)
+				.build();
+		mockExistingSocialAccount(notOnboarded);
+
+		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+
+		assertThat(response.isNewUser()).isTrue();
+	}
+
+	@Test
+	@DisplayName("재로그인이고 온보딩 완료면 isNewUser=false")
+	void reLogin_onboarded_returnsExistingUser() {
+		User onboarded = User.builder()
+				.nickname("실제닉네임")
+				.gender(GenderType.MALE)
+				.age(30)
+				.build();
+		onboarded.completeOnboarding();
+		mockExistingSocialAccount(onboarded);
+
+		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+
+		assertThat(response.isNewUser()).isFalse();
+	}
+
+	private void mockExistingSocialAccount(User user) {
+		UserSocialAccount socialAccount = UserSocialAccount.builder()
+				.user(user)
+				.provider(OauthProvider.KAKAO)
+				.providerUid(KAKAO_ID.toString())
+				.providerEmail("user@example.com")
+				.build();
+		when(userSocialAccountRepository.findByProviderAndProviderUid(OauthProvider.KAKAO, KAKAO_ID.toString()))
+				.thenReturn(Optional.of(socialAccount));
+	}
+}


### PR DESCRIPTION
## 문제

가장 처음 페이지에서 카카오 로그인 → 닉네임 설정 안 하고 뒤로가기 → 다시 로그인 버튼을 누르면 온보딩(닉네임 설정)을 건너뛰고 바로 로그인되어 버림.

## 원인

`AuthService.kakaoLogin()`이 `isNewUser`를 **"이번 요청에서 소셜 계정을 방금 만들었는지"**(`socialAccount == null`)로 판단했다. 하지만 첫 콜백 시점에 이미 `User`/`UserSocialAccount`를 즉시 저장(기본 닉네임 `kakao_<id>`)하므로, 닉네임 미설정 상태로 이탈 후 재로그인하면 소셜 계정이 존재해 `isNewUser=false`가 되고 FE가 온보딩을 건너뛴다. 사용자는 기본 닉네임에 갇혀 온보딩을 영영 못 한다.

## 수정

`isNewUser` 신호를 **"온보딩(닉네임 설정) 완료 여부"** 기준으로 변경.

- `users.onboarding_completed` 컬럼 추가 (`V28`). 기본값 false, 기존 사용자 중 실제 닉네임(비 `kakao_` 접두어) 보유자는 true로 백필
- `User.completeOnboarding()` 추가 → 프로필 생성/수정(`POST/PUT /api/user/profile`)에서 닉네임이 설정되면 마킹
- `AuthService`: `isNewUser = !user.isOnboardingCompleted()` 로 판단 변경 → 닉네임 미설정 이탈 후 재로그인해도 계속 온보딩으로 안내

## 테스트

`AuthServiceOnboardingTest` 3케이스 추가/통과:
- 최초 로그인 → `isNewUser=true`
- 재로그인·온보딩 미완료(버그 재현 케이스) → `isNewUser=true`
- 재로그인·온보딩 완료 → `isNewUser=false`

## 참고

- 응답 JSON 필드명 `isNewUser`는 유지 → **FE 계약 변경 없음**. 의미만 "온보딩 필요 여부"로 정정됨.
- 온보딩 완료 표시 시점은 `POST /api/user/profile`(닉네임 포함 프로필 생성) 성공 시. FE가 닉네임 설정을 이 엔드포인트로 제출하는지 확인 필요.
- 마이그레이션 백필은 `kakao_`로 시작하지 않는 닉네임을 온보딩 완료로 간주 — 정상 닉네임에 `kakao_` 접두어를 쓴 케이스가 있다면 재검토 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)