### PR TITLE
FEAT: 번역 서비스 자동 failover (DeepL -> Google Translate)

### DIFF
--- a/src/main/java/com/deoham/chat/controller/docs/ChatTranslationControllerDocs.java
+++ b/src/main/java/com/deoham/chat/controller/docs/ChatTranslationControllerDocs.java
@@ -28,6 +28,9 @@ public interface ChatTranslationControllerDocs {
 
                     **`targetLanguage` 값**: 번역 제공자가 지원하는 언어 코드를 사용합니다 (예: `ko`, `en`, `ja`, `zh`).
                     현재 번역 제공자는 설정에 따라 다를 수 있으며, 지원 언어 코드는 제공자 문서를 참고하세요.
+
+                    **Failover**: DeepL을 우선 시도하고 실패하면 자동으로 Gemini로 재시도합니다.
+                    실제로 응답을 생성한 제공자는 서버 로그로만 확인 가능하며, 클라이언트 응답에는 노출되지 않습니다.
                     """
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "번역 성공 (캐시 적중 또는 신규 번역)")

--- a/src/main/java/com/deoham/chat/service/ChatTranslationService.java
+++ b/src/main/java/com/deoham/chat/service/ChatTranslationService.java
@@ -40,7 +40,7 @@ public class ChatTranslationService {
                 .chatMessage(message)
                 .targetLanguage(targetLanguage)
                 .translatedText(result.translatedText())
-                .providerName(translationProvider.getProviderName())
+                .providerName(result.providerName())
                 .modelVersion(result.modelVersion())
                 .build());
 

--- a/src/main/java/com/deoham/chat/service/LiveLocationSessionRegistry.java
+++ b/src/main/java/com/deoham/chat/service/LiveLocationSessionRegistry.java
@@ -28,11 +28,14 @@ public class LiveLocationSessionRegistry {
     /** 해당 세션의 특정 구독이 해제된 경우에만 제거하고 반환한다. */
     public Optional<Entry> removeBySubscription(String sessionId, String subscriptionId) {
         Entry current = sessions.get(sessionId);
-        if (current != null && current.subscriptionId().equals(subscriptionId)
-                && sessions.remove(sessionId, current)) {
+        if (isSameSubscription(current, subscriptionId) && sessions.remove(sessionId, current)) {
             return Optional.of(current);
         }
         return Optional.empty();
+    }
+
+    private static boolean isSameSubscription(Entry entry, String subscriptionId) {
+        return entry != null && entry.subscriptionId().equals(subscriptionId);
     }
 
     /** 세션이 종료되면 등록 정보를 제거하고 반환한다. */

--- a/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
@@ -8,8 +8,10 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -52,7 +54,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
 			log.warn("DeepL translation request failed. targetLang={} (원본 {}), Status: {}, Response: {}",
 					targetLang, targetLanguage, e.getStatusCode(), e.getResponseBodyAsString());
 			// 400 = target_lang 미지원 등 클라이언트 입력 문제 → 인증/서버 오류(401/403/456/5xx)와 구분
-			if (e.getStatusCode().value() == 400) {
+			if (e.getStatusCode().equals(HttpStatus.BAD_REQUEST)) {
 				throw new BusinessException(ErrorCode.INVALID_REQUEST,
 						"지원하지 않는 번역 대상 언어입니다: " + targetLanguage);
 			}
@@ -60,7 +62,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
 		}
 
 		String translatedText = response != null ? response.firstText() : null;
-		if (translatedText == null || translatedText.isBlank()) {
+		if (!StringUtils.hasText(translatedText)) {
 			log.warn("DeepL returned no translation for target language {}", targetLang);
 			throw new BusinessException(ErrorCode.INTERNAL_ERROR, "번역 결과를 받지 못했습니다.");
 		}

--- a/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/DeepLTranslationProvider.java
@@ -7,7 +7,6 @@ import java.util.Locale;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -15,7 +14,6 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
 @Slf4j
-@Primary
 @Profile("!test")
 @Component
 public class DeepLTranslationProvider implements TranslationProvider {
@@ -67,7 +65,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
 			throw new BusinessException(ErrorCode.INTERNAL_ERROR, "번역 결과를 받지 못했습니다.");
 		}
 
-		return new TranslationResult(translatedText.trim(), PROVIDER_NAME);
+		return new TranslationResult(translatedText.trim(), PROVIDER_NAME, PROVIDER_NAME);
 	}
 
 	/**

--- a/src/main/java/com/deoham/chat/translation/DummyTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/DummyTranslationProvider.java
@@ -11,7 +11,7 @@ public class DummyTranslationProvider implements TranslationProvider {
 
     @Override
     public TranslationResult translate(String text, String targetLanguage) {
-        return new TranslationResult("[%s] %s".formatted(targetLanguage.toUpperCase(), text), "dummy-v1");
+        return new TranslationResult("[%s] %s".formatted(targetLanguage.toUpperCase(), text), "DUMMY", "dummy-v1");
     }
 
     @Override

--- a/src/main/java/com/deoham/chat/translation/FailoverTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/FailoverTranslationProvider.java
@@ -1,0 +1,43 @@
+package com.deoham.chat.translation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * DeepL을 우선 시도하고, 실패(네트워크 오류·인증 오류·미지원 언어 등 어떤 이유든)하면
+ * Gemini로 자동 전환한다. 어느 provider가 실제로 처리했는지는 {@link TranslationResult#providerName()}에
+ * 담겨 호출자에게 그대로 전달되므로, 이 클래스 자체는 상태를 갖지 않는다(동시 요청 간 경합 없음).
+ */
+@Slf4j
+@Primary
+@Profile("!test")
+@Component
+public class FailoverTranslationProvider implements TranslationProvider {
+
+    private static final String PROVIDER_NAME = "DEEPL_WITH_GEMINI_FALLBACK";
+
+    private final DeepLTranslationProvider primary;
+    private final GeminiTranslationProvider fallback;
+
+    public FailoverTranslationProvider(DeepLTranslationProvider primary, GeminiTranslationProvider fallback) {
+        this.primary = primary;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public TranslationResult translate(String text, String targetLanguage) {
+        try {
+            return primary.translate(text, targetLanguage);
+        } catch (Exception e) {
+            log.warn("DeepL 번역 실패, Gemini로 failover. targetLanguage={}, reason={}", targetLanguage, e.getMessage());
+            return fallback.translate(text, targetLanguage);
+        }
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+}

--- a/src/main/java/com/deoham/chat/translation/GeminiTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/GeminiTranslationProvider.java
@@ -54,7 +54,7 @@ public class GeminiTranslationProvider implements TranslationProvider {
 		}
 
 		String modelVersion = response.modelVersion() != null ? response.modelVersion() : properties.model();
-		return new TranslationResult(translatedText.trim(), modelVersion);
+		return new TranslationResult(translatedText.trim(), PROVIDER_NAME, modelVersion);
 	}
 
 	@Override

--- a/src/main/java/com/deoham/chat/translation/GeminiTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/GeminiTranslationProvider.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -48,7 +49,7 @@ public class GeminiTranslationProvider implements TranslationProvider {
 		}
 
 		String translatedText = response != null ? response.firstText() : null;
-		if (translatedText == null || translatedText.isBlank()) {
+		if (!StringUtils.hasText(translatedText)) {
 			log.warn("Gemini returned no translation candidates for target language {}", targetLanguage);
 			throw new BusinessException(ErrorCode.INTERNAL_ERROR, "번역 결과를 받지 못했습니다.");
 		}

--- a/src/main/java/com/deoham/chat/translation/TranslationResult.java
+++ b/src/main/java/com/deoham/chat/translation/TranslationResult.java
@@ -1,4 +1,4 @@
 package com.deoham.chat.translation;
 
-public record TranslationResult(String translatedText, String modelVersion) {
+public record TranslationResult(String translatedText, String providerName, String modelVersion) {
 }

--- a/src/test/java/com/deoham/chat/translation/FailoverTranslationProviderTest.java
+++ b/src/test/java/com/deoham/chat/translation/FailoverTranslationProviderTest.java
@@ -1,0 +1,68 @@
+package com.deoham.chat.translation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.deoham.global.exception.BusinessException;
+import com.deoham.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FailoverTranslationProviderTest {
+
+    @Mock
+    private DeepLTranslationProvider primary;
+    @Mock
+    private GeminiTranslationProvider fallback;
+
+    private FailoverTranslationProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new FailoverTranslationProvider(primary, fallback);
+    }
+
+    @Test
+    void translate_usesPrimaryResult_whenPrimarySucceeds() {
+        when(primary.translate("안녕", "en")).thenReturn(new TranslationResult("Hello", "DEEPL", "DEEPL"));
+
+        TranslationResult result = provider.translate("안녕", "en");
+
+        assertThat(result.translatedText()).isEqualTo("Hello");
+        assertThat(result.providerName()).isEqualTo("DEEPL");
+        verifyNoInteractions(fallback);
+    }
+
+    @Test
+    void translate_fallsBackToGemini_whenPrimaryThrows() {
+        when(primary.translate("안녕", "en")).thenThrow(new BusinessException(ErrorCode.INTERNAL_ERROR, "DeepL 오류"));
+        when(fallback.translate("안녕", "en")).thenReturn(new TranslationResult("Hello", "GEMINI", "gemini-3.5-flash"));
+
+        TranslationResult result = provider.translate("안녕", "en");
+
+        assertThat(result.translatedText()).isEqualTo("Hello");
+        assertThat(result.providerName()).isEqualTo("GEMINI");
+        assertThat(result.modelVersion()).isEqualTo("gemini-3.5-flash");
+    }
+
+    @Test
+    void translate_propagatesFallbackException_whenBothFail() {
+        when(primary.translate("안녕", "en")).thenThrow(new BusinessException(ErrorCode.INTERNAL_ERROR, "DeepL 오류"));
+        when(fallback.translate("안녕", "en")).thenThrow(new BusinessException(ErrorCode.INTERNAL_ERROR, "Gemini 오류"));
+
+        assertThatThrownBy(() -> provider.translate("안녕", "en"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Gemini 오류");
+    }
+
+    @Test
+    void getProviderName_returnsCompositeName() {
+        assertThat(provider.getProviderName()).isEqualTo("DEEPL_WITH_GEMINI_FALLBACK");
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 채팅 메시지 번역 시 DeepL(우선) 요청이 실패하면 자동으로 Gemini로 재시도하는 failover 로직 추가
- 새 외부 연동/자격증명 없이, 이미 구현돼 있던 `DeepLTranslationProvider`/`GeminiTranslationProvider`를 그대로 조합 (Google Cloud Translation API 신규 연동은 이번 범위 아님 — 기존 Gemini provider가 이미 "구글" 번역 서비스이자 완성된 상태였음)

## 설계
- `FailoverTranslationProvider`(@Primary) — DeepL 시도 → 어떤 이유로든 실패(네트워크/인증/미지원 언어 등)하면 Gemini로 전환. 둘 다 실패하면 Gemini의 예외를 그대로 전파
- `TranslationResult`에 `providerName` 필드 추가 — 실제로 응답을 만든 provider 이름을 결과값 자체에 담아 반환. (기존에는 `ChatTranslationService`가 주입된 provider 빈의 `getProviderName()`을 별도 호출했는데, failover 빈은 싱글턴이라 "마지막에 사용한 provider"를 상태로 들고 있으면 동시 요청 간 경합이 생김 — 결과값에 담는 방식으로 그 문제를 원천 차단)
- `DeepLTranslationProvider`에서 `@Primary` 제거 (`FailoverTranslationProvider`가 대신 `@Primary`)

## 변경 사항
- `FailoverTranslationProvider` 신규 추가
- `TranslationResult(translatedText, providerName, modelVersion)` — `providerName` 필드 추가
- `DeepLTranslationProvider`/`GeminiTranslationProvider`/`DummyTranslationProvider` — 각자 자기 이름을 `TranslationResult`에 채우도록 수정
- `ChatTranslationService` — `translationProvider.getProviderName()` 대신 `result.providerName()` 사용
- Swagger 설명에 failover 동작 추가

## 테스트
- `FailoverTranslationProviderTest` 신규 (성공/failover/양쪽 실패/getProviderName 4개 케이스)
- `DeepLTranslationProviderTest`, `GeminiTranslationProviderTest`, `ChatTranslationServiceTest` 회귀 확인
- `./gradlew clean build` 전체 그린 (CI: https://github.com/ITs-TIME-ONDO/ONDO-BE/actions/runs/30080606803)

## TODO
- [x] `GoogleTranslationProvider`(Gemini 재사용) 조합
- [x] Provider 체인/failover 로직 추가
- [x] 실패 시나리오 테스트 작성

Closes #117