### PR TITLE
FEAT: HttpOnly 기반 인증 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,6 @@ jobs:
           # JWT — HS256 signing secret (최소 32자)
           JWT_SECRET=${{ secrets.JWT_SECRET }}
 
-          # Supabase JWT — Firebase 전환 전 임시 플레이스홀더 (Swagger 접근용)
-          SUPABASE_JWT_ISSUER=https://placeholder.supabase.co/auth/v1
-          SUPABASE_JWT_JWKS_URI=https://placeholder.supabase.co/auth/v1/.well-known/jwks.json
-          SUPABASE_JWT_AUDIENCE=authenticated
-
           # AWS S3 (필수 — @NotBlank/@Positive, EC2 IAM 역할로 자격증명 자동 처리)
           AWS_S3_REGION=${{ secrets.AWS_S3_REGION }}
           AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deoham-BE
 
-Spring Boot 3.5 / Java 17 backend for Deoham. Auth via Supabase (Kakao OAuth → Supabase JWT). Postgres on Supabase, Redis cache, S3 file storage.
+Spring Boot 3.5 / Java 17 backend for Deoham. Auth via Kakao OAuth + self-issued HS256 JWT. PostgreSQL + Redis cache, S3 file storage.
 
 ## Prerequisites
 
@@ -21,15 +21,9 @@ Spring Boot's docker-compose support auto-starts Postgres+Redis from `compose.ya
 
 ## Configuration
 
-Local defaults are in `src/main/resources/application-local.yml`. To hit a real Supabase project locally, override:
+Local defaults are in `src/main/resources/application-local.yml`.
 
-```bash
-SUPABASE_JWT_ISSUER=https://<ref>.supabase.co/auth/v1\
-SUPABASE_JWT_JWKS_URI=https://<ref>.supabase.co/auth/v1/.well-known/jwks.json\
-  ./gradlew bootRun
-```
-
-Secrets (Kakao OAuth keys, Gemini API key, etc.) are kept out of the yml files and loaded from a local `.env` file, gitignored and never committed:
+Secrets (Kakao OAuth keys, Gemini API key, JWT secret, etc.) are kept out of the yml files and loaded from a local `.env` file, gitignored and never committed:
 
 ```bash
 cp .env.example .env   # then fill in the real values
@@ -52,4 +46,4 @@ docker build -t deoham-be .   # container image
 
 ## Layout
 
-See `CLAUDE.md` for architecture, package layout, auth flow, and Supabase connection notes.
+See `CLAUDE.md` for architecture, package layout, and auth flow details.

--- a/src/main/java/com/deoham/auth/controller/AuthController.java
+++ b/src/main/java/com/deoham/auth/controller/AuthController.java
@@ -3,11 +3,15 @@ package com.deoham.auth.controller;
 import com.deoham.auth.controller.docs.AuthControllerDocs;
 import com.deoham.auth.dto.KakaoCallbackRequest;
 import com.deoham.auth.dto.KakaoCallbackResponse;
-import com.deoham.auth.dto.RefreshTokenRequest;
+import com.deoham.auth.dto.KakaoLoginResult;
 import com.deoham.auth.dto.TokenResponse;
 import com.deoham.auth.service.AuthService;
+import com.deoham.global.config.HttpOnlyAuthProperties;
 import com.deoham.global.metrics.MetricEndpoint;
 import com.deoham.global.response.ApiResponse;
+import com.deoham.global.security.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthControllerDocs {
 
 	private final AuthService authService;
+	private final HttpOnlyAuthProperties httpOnlyAuthProperties;
 
 	@Override
 	@GetMapping("/kakao")
@@ -38,26 +43,65 @@ public class AuthController implements AuthControllerDocs {
 	@Override
 	@PostMapping("/kakao/callback")
 	@MetricEndpoint("auth.kakao.callback")
-	public ResponseEntity<KakaoCallbackResponse> kakaoCallback(
-			@RequestBody @Valid KakaoCallbackRequest request
+	public ResponseEntity<ApiResponse<KakaoCallbackResponse>> kakaoCallback(
+			@RequestBody @Valid KakaoCallbackRequest request,
+			HttpServletResponse response
 	) {
-		return ResponseEntity.ok(authService.kakaoLogin(request.code(), request.state()));
+		KakaoLoginResult loginResult = authService.kakaoLogin(request.code(), request.state());
+
+		// refreshToken을 HttpOnly 쿠키로 설정
+		CookieUtils.setRefreshTokenCookie(
+				response,
+				loginResult.refreshToken(),
+				httpOnlyAuthProperties.secureCookie()
+		);
+
+		// accessToken은 Authorization 헤더에 담아서 반환
+		response.addHeader("Authorization", "Bearer " + loginResult.accessToken());
+
+		// Response body는 ApiResponse로 감싸서 반환 (CLAUDE.md 규칙 준수)
+		return ResponseEntity.ok(ApiResponse.ok(new KakaoCallbackResponse(loginResult.isNewUser())));
 	}
 
 	@Override
 	@PostMapping("/refresh")
 	@MetricEndpoint("auth.refresh")
-	public ResponseEntity<ApiResponse<TokenResponse>> refresh(
-			@RequestBody @Valid RefreshTokenRequest request
+	public ResponseEntity<ApiResponse<Void>> refresh(
+			HttpServletRequest request,
+			HttpServletResponse response
 	) {
-		return ResponseEntity.ok(ApiResponse.ok(authService.refresh(request.refreshToken())));
+		// 쿠키에서 refreshToken 자동 추출
+		String refreshToken = CookieUtils.getRefreshTokenFromCookie(request);
+
+		TokenResponse tokenResponse = authService.refresh(refreshToken);
+
+		// accessToken은 Authorization 헤더에만 담기
+		response.addHeader("Authorization", "Bearer " + tokenResponse.accessToken());
+
+		// 새로운 refreshToken이 있으면 쿠키에만 설정
+		if (tokenResponse.refreshToken() != null) {
+			CookieUtils.setRefreshTokenCookie(
+					response,
+					tokenResponse.refreshToken(),
+					httpOnlyAuthProperties.secureCookie()
+			);
+		}
+
+		return ResponseEntity.ok(ApiResponse.ok(null));
 	}
 
 	@Override
 	@PostMapping("/logout")
 	@MetricEndpoint("auth.logout")
-	public ResponseEntity<ApiResponse<Void>> logout(Authentication authentication) {
+	public ResponseEntity<ApiResponse<Void>> logout(
+			Authentication authentication,
+			HttpServletResponse response
+	) {
 		authService.logout(authentication);
+
+		// refreshToken 쿠키 삭제
+		CookieUtils.deleteRefreshTokenCookie(response, httpOnlyAuthProperties.secureCookie());
+
 		return ResponseEntity.ok(ApiResponse.ok(null));
 	}
 }

--- a/src/main/java/com/deoham/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/deoham/auth/controller/docs/AuthControllerDocs.java
@@ -2,8 +2,6 @@ package com.deoham.auth.controller.docs;
 
 import com.deoham.auth.dto.KakaoCallbackRequest;
 import com.deoham.auth.dto.KakaoCallbackResponse;
-import com.deoham.auth.dto.RefreshTokenRequest;
-import com.deoham.auth.dto.TokenResponse;
 import com.deoham.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -11,6 +9,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -42,53 +42,81 @@ public interface AuthControllerDocs {
 			description = "프론트엔드가 카카오로부터 받은 인가 코드를 백엔드로 전달합니다. " +
 					"요청에는 카카오 리다이렉트 쿼리의 code와 state를 모두 포함해야 합니다. " +
 					"백엔드가 카카오 API와 직접 토큰 교환 및 유저 정보 조회를 수행하고, " +
-					"우리 서버의 JWT를 발급합니다. 최초 로그인이면 isNewUser=true를 반환합니다."
+					"우리 서버의 JWT를 발급합니다. " +
+					"AccessToken은 Authorization 헤더, RefreshToken은 HttpOnly 쿠키로 반환됩니다. " +
+					"응답: { \"success\": true, \"data\": { \"isNewUser\": boolean }, \"error\": null }"
 	)
 	@ApiResponses({
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "200",
-					description = "로그인/회원가입 성공, JWT 반환",
-					content = @Content(schema = @Schema(implementation = KakaoCallbackResponse.class))
+					description = "로그인/회원가입 성공, AccessToken(헤더) + RefreshToken(쿠키) + 신규사용자 여부(body) 반환",
+					headers = @Header(name = "Authorization", description = "Bearer {accessToken}", schema = @Schema(type = "string")),
+					content = @Content(
+						mediaType = "application/json",
+						schema = @Schema(
+							example = "{\"success\": true, \"data\": {\"isNewUser\": false}, \"error\": null}",
+							type = "object",
+							implementation = ApiResponse.class
+						)
+					)
 			),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "400",
-					description = "입력값 검증 실패",
-					content = @Content
+					description = "입력값 검증 실패 (code 또는 state 누락)",
+					content = @Content(
+						mediaType = "application/json",
+						schema = @Schema(example = "{\"success\": false, \"data\": null, \"error\": {\"code\": \"INVALID_REQUEST\", \"message\": \"...\"}}")
+					)
 			),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "401",
-					description = "유효하지 않은 인가 코드",
-					content = @Content
+					description = "유효하지 않은 인가 코드 또는 expired OAuth state",
+					content = @Content(
+						mediaType = "application/json",
+						schema = @Schema(example = "{\"success\": false, \"data\": null, \"error\": {\"code\": \"UNAUTHORIZED\", \"message\": \"Invalid OAuth state\"}}")
+					)
 			)
 	})
-	ResponseEntity<KakaoCallbackResponse> kakaoCallback(@Valid KakaoCallbackRequest request);
+	ResponseEntity<ApiResponse<KakaoCallbackResponse>> kakaoCallback(@Valid KakaoCallbackRequest request, HttpServletResponse response);
 
 	@Operation(
 			summary = "액세스 토큰 갱신",
 			description = "만료된 액세스 토큰을 리프레시 토큰으로 갱신합니다. " +
-					"갱신 시 리프레시 토큰도 함께 회전(rotation)되어 새 리프레시 토큰이 발급되며, " +
-					"기존 리프레시 토큰은 더 이상 사용할 수 없습니다. 응답의 refreshToken을 반드시 교체 저장하세요."
+					"RefreshToken은 자동으로 쿠키에서 추출되므로 요청 바디에 포함할 필요가 없습니다. " +
+					"갱신 시 만료 임박한 리프레시 토큰은 자동 회전되며, 새 RefreshToken이 발급되면 쿠키에 설정됩니다. " +
+					"AccessToken은 Authorization 헤더, RefreshToken은 HttpOnly 쿠키로만 반환됩니다."
 	)
 	@ApiResponses({
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "200",
-					description = "토큰 갱신 성공",
-					content = @Content(schema = @Schema(implementation = TokenResponse.class))
+					description = "토큰 갱신 성공, 새 AccessToken(헤더) + 갱신된 RefreshToken(쿠키, 필요시) 반환",
+					headers = @Header(name = "Authorization", description = "Bearer {newAccessToken}", schema = @Schema(type = "string")),
+					content = @Content(
+						mediaType = "application/json",
+						schema = @Schema(
+							example = "{\"success\": true, \"data\": null, \"error\": null}",
+							type = "object",
+							implementation = ApiResponse.class
+						)
+					)
 			),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "401",
-					description = "유효하지 않거나 만료된 리프레시 토큰",
-					content = @Content
+					description = "유효하지 않거나 만료된 리프레시 토큰, 또는 토큰 없음",
+					content = @Content(
+						mediaType = "application/json",
+						schema = @Schema(example = "{\"success\": false, \"data\": null, \"error\": {\"code\": \"UNAUTHORIZED\", \"message\": \"Refresh token has expired\"}}")
+					)
 			)
 	})
-	ResponseEntity<ApiResponse<TokenResponse>> refresh(@Valid RefreshTokenRequest request);
+	ResponseEntity<ApiResponse<Void>> refresh(HttpServletRequest request, HttpServletResponse response);
 
-	@Operation(summary = "로그아웃", description = "현재 사용자에게 저장된 리프레시 토큰을 모두 폐기합니다. " +
+	@Operation(summary = "로그아웃", description = "현재 사용자에게 저장된 리프레시 토큰을 모두 폐기하고 쿠키를 삭제합니다. " +
 			"발급된 액세스 토큰은 만료 시까지 유효하므로, 클라이언트에서도 저장된 토큰을 삭제해야 합니다.")
 	@ApiResponses({
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "200",
-					description = "로그아웃 성공 (data: null)"
+					description = "로그아웃 성공 (RefreshToken 쿠키 삭제됨)"
 			),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "401",
@@ -96,5 +124,5 @@ public interface AuthControllerDocs {
 					content = @Content
 			)
 	})
-	ResponseEntity<ApiResponse<Void>> logout(Authentication authentication);
+	ResponseEntity<ApiResponse<Void>> logout(Authentication authentication, HttpServletResponse response);
 }

--- a/src/main/java/com/deoham/auth/dto/KakaoCallbackResponse.java
+++ b/src/main/java/com/deoham/auth/dto/KakaoCallbackResponse.java
@@ -2,21 +2,15 @@ package com.deoham.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * 카카오 로그인 콜백 응답
+ * - accessToken: Authorization 헤더를 통해 전달
+ * - refreshToken: HttpOnly 쿠키를 통해 전달
+ * - isNewUser: 응답 바디에 포함
+ */
 @Schema(description = "카카오 로그인 콜백 응답")
 public record KakaoCallbackResponse(
-		@Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-		String accessToken,
-
-		@Schema(description = "리프레시 토큰", example = "v1.abc123...")
-		String refreshToken,
-
-		@Schema(description = "토큰 타입", example = "Bearer")
-		String tokenType,
-
-		@Schema(description = "액세스 토큰 만료 시간 (초)", example = "3600")
-		long expiresIn,
-
-		@Schema(description = "신규 사용자 여부", example = "true")
+		@Schema(description = "신규 사용자 여부 (온보딩 미완료)", example = "true")
 		boolean isNewUser
 ) {
 }

--- a/src/main/java/com/deoham/auth/dto/KakaoLoginResult.java
+++ b/src/main/java/com/deoham/auth/dto/KakaoLoginResult.java
@@ -1,0 +1,14 @@
+package com.deoham.auth.dto;
+
+/**
+ * AuthService.kakaoLogin()의 내부 반환 DTO
+ * - accessToken: Authorization 헤더에 설정
+ * - refreshToken: HttpOnly 쿠키에 설정
+ * - isNewUser: 응답 바디에 포함
+ */
+public record KakaoLoginResult(
+		String accessToken,
+		String refreshToken,
+		boolean isNewUser
+) {
+}

--- a/src/main/java/com/deoham/auth/service/AuthService.java
+++ b/src/main/java/com/deoham/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.deoham.auth.client.KakaoOAuthClient;
 import com.deoham.auth.client.KakaoTokenResponse;
 import com.deoham.auth.client.KakaoUserInfo;
 import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.dto.KakaoLoginResult;
 import com.deoham.auth.dto.TokenResponse;
 import com.deoham.auth.entity.OAuthState;
 import com.deoham.auth.repository.OAuthStateRepository;
@@ -69,7 +70,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public KakaoCallbackResponse kakaoLogin(String code, String state) {
+	public KakaoLoginResult kakaoLogin(String code, String state) {
 		consumeOAuthState(state, OauthProvider.KAKAO);
 
 		KakaoTokenResponse kakaoToken = kakaoOAuthClient.exchangeCode(code);
@@ -117,16 +118,18 @@ public class AuthService {
 		// 온보딩이 미완료면 계속 신규 사용자로 안내한다.
 		boolean needsOnboarding = !user.isOnboardingCompleted();
 
-		return new KakaoCallbackResponse(
+		return new KakaoLoginResult(
 				accessToken,
 				refreshToken,
-				"Bearer",
-				jwtProperties.accessTokenExpirySeconds(),
 				needsOnboarding);
 	}
 
 	@Transactional
 	public TokenResponse refresh(String refreshToken) {
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED, "Refresh token is required.");
+		}
+
 		Jwt jwt;
 		try {
 			jwt = jwtTokenProvider.parseToken(refreshToken);
@@ -153,11 +156,21 @@ public class AuthService {
 		User user = socialAccount.getUser();
 		String newAccessToken = jwtTokenProvider.generateAccessToken(
 				user.getId(), socialAccount.getProviderEmail(), user.getRole().name());
-		String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
-		socialAccount.updateTokens(
-				null,
-				newRefreshToken,
-				Instant.now().plusSeconds(jwtProperties.refreshTokenExpirySeconds()));
+
+		// refreshToken 만료 임박 시 (24시간 이내) 갱신, 아니면 기존 토큰 유지
+		String newRefreshToken = null;
+		Instant newTokenExpiresAt = socialAccount.getTokenExpiresAt();
+
+		Instant renewalThreshold = Instant.now().plusSeconds(24 * 60 * 60); // 24 hours
+		if (newTokenExpiresAt.isBefore(renewalThreshold)) {
+			// RefreshToken 갱신
+			newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
+			newTokenExpiresAt = Instant.now().plusSeconds(jwtProperties.refreshTokenExpirySeconds());
+		}
+
+		if (newRefreshToken != null) {
+			socialAccount.updateTokens(null, newRefreshToken, newTokenExpiresAt);
+		}
 
 		return new TokenResponse(
 				newAccessToken,

--- a/src/main/java/com/deoham/card/controller/CardApplyController.java
+++ b/src/main/java/com/deoham/card/controller/CardApplyController.java
@@ -1,0 +1,48 @@
+package com.deoham.card.controller;
+
+import com.deoham.card.controller.docs.CardApplyControllerDocs;
+import com.deoham.card.dto.response.CardApplySummaryResponse;
+import com.deoham.card.service.CardReadService;
+import com.deoham.card.service.CardWriteService;
+import com.deoham.global.metrics.MetricEndpoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.deoham.global.security.AuthenticationUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/cards")
+@RequiredArgsConstructor
+public class CardApplyController implements CardApplyControllerDocs {
+
+	private final CardReadService cardReadService;
+	private final CardWriteService cardWriteService;
+
+	@Override
+	@MetricEndpoint("card.apply.submit")
+	@PostMapping("/{cardId}/applies")
+	public ResponseEntity<CardApplySummaryResponse> submitApply(
+			@PathVariable UUID cardId
+	) {
+		UUID userId = AuthenticationUtils.requiredUserId();
+		return ResponseEntity.status(HttpStatus.CREATED).body(cardWriteService.submitApply(cardId, userId));
+	}
+
+	@Override
+	@MetricEndpoint("card.apply.list")
+	@GetMapping("/{cardId}/applies")
+	public ResponseEntity<List<CardApplySummaryResponse>> getApplies(
+			@PathVariable UUID cardId
+	) {
+		UUID userId = AuthenticationUtils.requiredUserId();
+		return ResponseEntity.ok(cardReadService.getApplies(cardId, userId));
+	}
+}

--- a/src/main/java/com/deoham/card/controller/CardController.java
+++ b/src/main/java/com/deoham/card/controller/CardController.java
@@ -1,9 +1,7 @@
 package com.deoham.card.controller;
 
-import com.deoham.card.controller.docs.CardApplyControllerDocs;
 import com.deoham.card.controller.docs.CardControllerDocs;
 import com.deoham.card.dto.request.CreateCardRequest;
-import com.deoham.card.dto.response.CardApplySummaryResponse;
 import com.deoham.card.dto.response.CardDetailResponse;
 import com.deoham.card.dto.response.MyActiveCardResponse;
 import com.deoham.card.dto.response.PaginatedCardListResponse;
@@ -26,13 +24,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class CardController implements CardControllerDocs, CardApplyControllerDocs {
+public class CardController implements CardControllerDocs {
 
     private final CardReadService cardReadService;
     private final CardWriteService cardWriteService;
@@ -105,25 +102,5 @@ public class CardController implements CardControllerDocs, CardApplyControllerDo
         UUID userId = AuthenticationUtils.requiredUserId();
         cardWriteService.retryCard(cardId, userId);
         return ResponseEntity.noContent().build();
-    }
-
-    @Override
-    @MetricEndpoint("card.apply.submit")
-    @PostMapping("/cards/{cardId}/applies")
-    public ResponseEntity<CardApplySummaryResponse> submitApply(
-            @PathVariable UUID cardId
-    ) {
-        UUID userId = AuthenticationUtils.requiredUserId();
-        return ResponseEntity.status(HttpStatus.CREATED).body(cardWriteService.submitApply(cardId, userId));
-    }
-
-    @Override
-    @MetricEndpoint("card.apply.list")
-    @GetMapping("/cards/{cardId}/applies")
-    public ResponseEntity<List<CardApplySummaryResponse>> getApplies(
-            @PathVariable UUID cardId
-    ) {
-        UUID userId = AuthenticationUtils.requiredUserId();
-        return ResponseEntity.ok(cardReadService.getApplies(cardId, userId));
     }
 }

--- a/src/main/java/com/deoham/global/config/HttpOnlyAuthProperties.java
+++ b/src/main/java/com/deoham/global/config/HttpOnlyAuthProperties.java
@@ -1,0 +1,20 @@
+package com.deoham.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * HttpOnly 기반 인증 설정
+ * - local 환경: Secure 플래그 비활성화 (localhost 지원)
+ * - prod 환경: Secure 플래그 활성화 (HTTPS 필수)
+ */
+@ConfigurationProperties(prefix = "app.auth.httponly")
+public record HttpOnlyAuthProperties(
+		/**
+		 * 쿠키의 Secure 플래그 활성화 여부
+		 * - true: HTTPS 연결만 쿠키 전송 (프로덕션)
+		 * - false: HTTP도 허용 (로컬 개발)
+		 */
+		boolean secureCookie
+) {
+	public static final HttpOnlyAuthProperties DEFAULT = new HttpOnlyAuthProperties(true);
+}

--- a/src/main/java/com/deoham/global/config/SecurityConfig.java
+++ b/src/main/java/com/deoham/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.deoham.global.config;
 
 import com.deoham.global.security.AppJwtAuthenticationConverter;
 import com.deoham.global.security.JwtProperties;
+import com.deoham.global.security.RefreshTokenFilter;
 import com.deoham.global.security.RestAccessDeniedHandler;
 import com.deoham.global.security.RestAuthenticationEntryPoint;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -32,7 +34,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class, KakaoOAuthProperties.class })
+@EnableConfigurationProperties({ JwtProperties.class, CorsProperties.class, KakaoOAuthProperties.class, HttpOnlyAuthProperties.class })
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -56,6 +58,7 @@ public class SecurityConfig {
 	private final CorsProperties corsProperties;
 	private final RestAuthenticationEntryPoint authenticationEntryPoint;
 	private final RestAccessDeniedHandler accessDeniedHandler;
+	private final RefreshTokenFilter refreshTokenFilter;
 
 	@Bean
 	public AppJwtAuthenticationConverter jwtAuthenticationConverter() {
@@ -106,8 +109,9 @@ public class SecurityConfig {
 		config.setAllowedOrigins(corsProperties.allowedOrigins());
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
-		config.setExposedHeaders(List.of("Location", "Content-Disposition"));
-		config.setAllowCredentials(true);
+		// Authorization 헤더 expose (accessToken을 response 헤더에서 읽을 수 있도록)
+		config.setExposedHeaders(List.of("Location", "Content-Disposition", "Authorization"));
+		config.setAllowCredentials(true); // HttpOnly 쿠키 전송을 위해 필수
 		config.setMaxAge(3600L);
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/deoham/global/security/CookieUtils.java
+++ b/src/main/java/com/deoham/global/security/CookieUtils.java
@@ -1,0 +1,63 @@
+package com.deoham.global.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieUtils {
+
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+	private static final String REFRESH_TOKEN_PATH = "/api/auth";
+	private static final int REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7 days
+
+	/**
+	 * Set refresh token as HttpOnly cookie
+	 */
+	public static void setRefreshTokenCookie(HttpServletResponse response, String refreshToken,
+			boolean isSecure) {
+		ResponseCookie cookie = ResponseCookie
+				.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+				.path(REFRESH_TOKEN_PATH)
+				.maxAge(REFRESH_TOKEN_MAX_AGE)
+				.httpOnly(true)
+				.secure(isSecure)
+				.sameSite("Strict")
+				.build();
+		response.addHeader("Set-Cookie", cookie.toString());
+	}
+
+	/**
+	 * Delete refresh token cookie (by setting max-age to 0)
+	 */
+	public static void deleteRefreshTokenCookie(HttpServletResponse response, boolean isSecure) {
+		ResponseCookie cookie = ResponseCookie
+				.from(REFRESH_TOKEN_COOKIE_NAME, "")
+				.path(REFRESH_TOKEN_PATH)
+				.maxAge(0)
+				.httpOnly(true)
+				.secure(isSecure)
+				.sameSite("Strict")
+				.build();
+		response.addHeader("Set-Cookie", cookie.toString());
+	}
+
+	/**
+	 * Extract refresh token from request cookies
+	 */
+	public static String getRefreshTokenFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return null;
+		}
+		return Arrays.stream(cookies)
+				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+				.map(Cookie::getValue)
+				.findFirst()
+				.orElse(null);
+	}
+}

--- a/src/main/java/com/deoham/global/security/RefreshTokenFilter.java
+++ b/src/main/java/com/deoham/global/security/RefreshTokenFilter.java
@@ -1,0 +1,35 @@
+package com.deoham.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * RefreshToken 쿠키를 파싱하는 필터
+ * - 쿠키에서 refreshToken 추출
+ * - 요청 속성에 저장 (나중에 필요시 접근 가능)
+ * - Authorization 헤더에는 accessToken만 포함되어야 함
+ *
+ * 주의: 이 필터는 정보 추출만 수행하고, 토큰 검증은 Spring Security가 담당
+ */
+@Slf4j
+@Component
+public class RefreshTokenFilter extends OncePerRequestFilter {
+
+	public static final String REFRESH_TOKEN_ATTRIBUTE = "refreshToken";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+			FilterChain filterChain) throws ServletException, IOException {
+		String refreshToken = CookieUtils.getRefreshTokenFromCookie(request);
+		if (refreshToken != null) {
+			request.setAttribute(REFRESH_TOKEN_ATTRIBUTE, refreshToken);
+		}
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -25,6 +25,11 @@ jwt:
   access-token-expiry-seconds: 3600
   refresh-token-expiry-seconds: 604800
 
+app:
+  auth:
+    httponly:
+      secure-cookie: false
+
 deoham:
   cors:
     allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:8080,http://127.0.0.1:3000,http://127.0.0.1:5173,http://127.0.0.1:8080,https://kauth.kakao.com

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,11 @@ server:
       enabled: true
       pattern: '%h %l %u %t "%r" %s %b %D'
 
+app:
+  auth:
+    httponly:
+      secure-cookie: true
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,11 @@ jwt:
   access-token-expiry-seconds: ${JWT_ACCESS_TOKEN_EXPIRY_SECONDS:3600}
   refresh-token-expiry-seconds: ${JWT_REFRESH_TOKEN_EXPIRY_SECONDS:604800}
 
+app:
+  auth:
+    httponly:
+      secure-cookie: true
+
 deoham:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://kauth.kakao.com,https://ondo-fe.vercel.app}

--- a/src/test/java/com/deoham/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/deoham/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.deoham.auth.controller;
 
 import com.deoham.auth.dto.KakaoCallbackRequest;
 import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.dto.KakaoLoginResult;
 import com.deoham.auth.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -62,27 +63,22 @@ class AuthControllerTest {
 		String state = "test_state_value";
 		KakaoCallbackRequest request = new KakaoCallbackRequest(code, state);
 
-		KakaoCallbackResponse mockResponse = new KakaoCallbackResponse(
+		KakaoLoginResult mockLoginResult = new KakaoLoginResult(
 				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token",
 				"refresh_token_test_12345",
-				"Bearer",
-				3600L,
 				true
 		);
 
 		when(authService.kakaoLogin(code, state))
-				.thenReturn(mockResponse);
+				.thenReturn(mockLoginResult);
 
 		// when & then
 		mockMvc.perform(post("/api/auth/kakao/callback")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.accessToken").value("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token"))
-				.andExpect(jsonPath("$.refreshToken").value("refresh_token_test_12345"))
-				.andExpect(jsonPath("$.tokenType").value("Bearer"))
-				.andExpect(jsonPath("$.expiresIn").value(3600))
-				.andExpect(jsonPath("$.isNewUser").value(true));
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.isNewUser").value(true));
 	}
 
 	@Test
@@ -93,23 +89,22 @@ class AuthControllerTest {
 		String state = "test_state_value";
 		KakaoCallbackRequest request = new KakaoCallbackRequest(code, state);
 
-		KakaoCallbackResponse mockResponse = new KakaoCallbackResponse(
+		KakaoLoginResult mockLoginResult = new KakaoLoginResult(
 				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test_access_token_existing",
 				"refresh_token_existing_12345",
-				"Bearer",
-				3600L,
 				false
 		);
 
 		when(authService.kakaoLogin(code, state))
-				.thenReturn(mockResponse);
+				.thenReturn(mockLoginResult);
 
 		// when & then
 		mockMvc.perform(post("/api/auth/kakao/callback")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.isNewUser").value(false));
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.isNewUser").value(false));
 	}
 
 	@Test

--- a/src/test/java/com/deoham/auth/controller/TestSecurityConfig.java
+++ b/src/test/java/com/deoham/auth/controller/TestSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.deoham.auth.controller;
 
+import com.deoham.global.config.HttpOnlyAuthProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,5 +17,10 @@ class TestSecurityConfig {
 				.csrf(csrf -> csrf.disable())
 				.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 		return http.build();
+	}
+
+	@Bean
+	public HttpOnlyAuthProperties httpOnlyAuthProperties() {
+		return new HttpOnlyAuthProperties(false);
 	}
 }

--- a/src/test/java/com/deoham/auth/service/AuthServiceOnboardingTest.java
+++ b/src/test/java/com/deoham/auth/service/AuthServiceOnboardingTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import com.deoham.auth.client.KakaoOAuthClient;
 import com.deoham.auth.client.KakaoTokenResponse;
 import com.deoham.auth.client.KakaoUserInfo;
-import com.deoham.auth.dto.KakaoCallbackResponse;
+import com.deoham.auth.dto.KakaoLoginResult;
 import com.deoham.auth.entity.OAuthState;
 import com.deoham.auth.repository.OAuthStateRepository;
 import com.deoham.global.config.KakaoOAuthProperties;
@@ -86,7 +86,7 @@ class AuthServiceOnboardingTest {
 		when(userSocialAccountRepository.save(any(UserSocialAccount.class)))
 				.thenAnswer(inv -> inv.getArgument(0));
 
-		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+		KakaoLoginResult response = authService.kakaoLogin(CODE, STATE);
 
 		assertThat(response.isNewUser()).isTrue();
 	}
@@ -101,7 +101,7 @@ class AuthServiceOnboardingTest {
 				.build();
 		mockExistingSocialAccount(notOnboarded);
 
-		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+		KakaoLoginResult response = authService.kakaoLogin(CODE, STATE);
 
 		assertThat(response.isNewUser()).isTrue();
 	}
@@ -117,7 +117,7 @@ class AuthServiceOnboardingTest {
 		onboarded.completeOnboarding();
 		mockExistingSocialAccount(onboarded);
 
-		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+		KakaoLoginResult response = authService.kakaoLogin(CODE, STATE);
 
 		assertThat(response.isNewUser()).isFalse();
 	}
@@ -145,7 +145,7 @@ class AuthServiceOnboardingTest {
 		when(userSocialAccountRepository.save(any(UserSocialAccount.class)))
 				.thenAnswer(inv -> inv.getArgument(0));
 
-		KakaoCallbackResponse response = authService.kakaoLogin(CODE, STATE);
+		KakaoLoginResult response = authService.kakaoLogin(CODE, STATE);
 
 		// 탈퇴된 사용자가 복구됨
 		assertThat(deletedAndOnboarded.getDeletedAt()).isNull();


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #120 //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- POST /api/auth/refresh 응답에서 토큰 제거 (헤더/쿠키에만 담기)
- AccessToken을 Authorization 헤더에만 담기
- RefreshToken을 HttpOnly 쿠키에만 담기
- Swagger 문서 업데이트

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
