### PR TITLE
REFACTOR: 번역 트랜잭션 범위 축소 (외부 API 호출을 트랜잭션 밖으로)

### DIFF
--- a/src/main/java/com/deoham/chat/service/ChatTranslationService.java
+++ b/src/main/java/com/deoham/chat/service/ChatTranslationService.java
@@ -1,64 +1,45 @@
 package com.deoham.chat.service;
 
 import com.deoham.chat.dto.ChatTranslationResponse;
-import com.deoham.chat.entity.ChatMessage;
-import com.deoham.chat.entity.ChatMessageTranslation;
-import com.deoham.chat.entity.ChatMessageType;
-import com.deoham.chat.repository.ChatMessageTranslationRepository;
+import com.deoham.chat.service.ChatTranslationStore.TranslationLookup;
 import com.deoham.chat.translation.TranslationProvider;
 import com.deoham.chat.translation.TranslationResult;
-import com.deoham.global.exception.BusinessException;
-import com.deoham.global.exception.ErrorCode;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 메시지 번역 흐름을 조율한다. 이 클래스 자체는 트랜잭션을 열지 않는다.
+ *
+ * <p>DB 트랜잭션은 {@link ChatTranslationStore}의 짧은 읽기/쓰기 구간에만 존재하고,
+ * 느린 외부 번역 API 호출은 두 트랜잭션 <b>사이</b>(트랜잭션 밖)에서 수행한다.
+ * 예전처럼 외부 호출 전 구간을 한 트랜잭션으로 감싸면 그 동안 DB 커넥션을 붙잡아,
+ * 번역 지연 시 HikariCP 풀이 고갈되고 번역과 무관한 요청까지 막힌다.
+ */
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ChatTranslationService {
 
-    private final ChatMessageTranslationRepository translationRepository;
-    private final ChatAccessGuard chatAccessGuard;
+    private final ChatTranslationStore store;
     private final TranslationProvider translationProvider;
 
     public ChatTranslationResponse translate(UUID requesterId, UUID messageId, String targetLanguage) {
-        ChatMessage message = chatAccessGuard.findMessageOrThrow(messageId);
-        chatAccessGuard.requireParticipant(message.getChatRoom().getCard(), requesterId);
-        requireTextMessage(message);
-
-        Optional<ChatMessageTranslation> cached =
-                translationRepository.findByChatMessageIdAndTargetLanguage(messageId, targetLanguage);
-        if (cached.isPresent()) {
-            return toResponse(cached.get(), true);
+        // 1) 권한 검증 + 캐시 조회 (짧은 읽기 트랜잭션)
+        TranslationLookup lookup = store.lookup(requesterId, messageId, targetLanguage);
+        if (lookup.isCached()) {
+            return lookup.cachedResponse();
         }
 
-        TranslationResult result = translationProvider.translate(message.getContent(), targetLanguage);
-        ChatMessageTranslation saved = translationRepository.save(ChatMessageTranslation.builder()
-                .chatMessage(message)
-                .targetLanguage(targetLanguage)
-                .translatedText(result.translatedText())
-                .providerName(result.providerName())
-                .modelVersion(result.modelVersion())
-                .build());
+        // 2) 외부 번역 API 호출 (트랜잭션 밖 — DB 커넥션을 점유하지 않는다)
+        TranslationResult result = translationProvider.translate(lookup.sourceText(), targetLanguage);
 
-        return toResponse(saved, false);
-    }
-
-    private void requireTextMessage(ChatMessage message) {
-        if (message.getMessageType() != ChatMessageType.TEXT) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST, "텍스트 메시지만 번역할 수 있습니다");
+        // 3) 결과 저장 (짧은 쓰기 트랜잭션)
+        try {
+            return store.save(messageId, targetLanguage, result);
+        } catch (DataIntegrityViolationException raced) {
+            // 동시 요청이 같은 (메시지, 언어)를 먼저 저장함 → 승자의 결과를 캐시로 반환
+            return store.getCached(messageId, targetLanguage);
         }
-    }
-
-    private ChatTranslationResponse toResponse(ChatMessageTranslation translation, boolean cached) {
-        return new ChatTranslationResponse(
-                translation.getChatMessage().getId(),
-                translation.getTargetLanguage(),
-                translation.getTranslatedText(),
-                cached,
-                translation.getTranslatedAt());
     }
 }

--- a/src/main/java/com/deoham/chat/service/ChatTranslationStore.java
+++ b/src/main/java/com/deoham/chat/service/ChatTranslationStore.java
@@ -1,0 +1,110 @@
+package com.deoham.chat.service;
+
+import com.deoham.chat.dto.ChatTranslationResponse;
+import com.deoham.chat.entity.ChatMessage;
+import com.deoham.chat.entity.ChatMessageTranslation;
+import com.deoham.chat.entity.ChatMessageType;
+import com.deoham.chat.repository.ChatMessageRepository;
+import com.deoham.chat.repository.ChatMessageTranslationRepository;
+import com.deoham.chat.translation.TranslationResult;
+import com.deoham.global.exception.BusinessException;
+import com.deoham.global.exception.ErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 번역 기능의 DB 작업(권한 검증 + 캐시 조회, 결과 저장)만 담당한다.
+ *
+ * <p>{@link ChatTranslationService}가 외부 번역 API 호출을 트랜잭션 <b>밖</b>에서 수행하도록,
+ * DB 트랜잭션 경계를 이 빈으로 분리했다. 오케스트레이터와 다른 빈이어야 Spring 프록시를 거쳐
+ * {@code @Transactional}이 실제로 적용된다(같은 빈 내 자기호출은 프록시를 우회함).
+ */
+@Component
+@RequiredArgsConstructor
+class ChatTranslationStore {
+
+    private final ChatMessageTranslationRepository translationRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatAccessGuard chatAccessGuard;
+
+    /**
+     * 접근 권한 검증과 캐시 조회를 한 읽기 트랜잭션에서 끝낸다. 캐시 히트면 완성된 응답을,
+     * 미스면 번역할 원문을 담아 돌려준다. 외부 API 호출이 이 트랜잭션 밖에서 이뤄지므로,
+     * 트랜잭션 종료 후 lazy 로딩이 필요 없도록 여기서 필요한 값을 모두 추출한다.
+     */
+    @Transactional(readOnly = true)
+    TranslationLookup lookup(UUID requesterId, UUID messageId, String targetLanguage) {
+        ChatMessage message = chatAccessGuard.findMessageOrThrow(messageId);
+        chatAccessGuard.requireParticipant(message.getChatRoom().getCard(), requesterId);
+        requireTextMessage(message);
+
+        return translationRepository.findByChatMessageIdAndTargetLanguage(messageId, targetLanguage)
+                .map(cached -> TranslationLookup.cached(toResponse(cached, true)))
+                .orElseGet(() -> TranslationLookup.needsTranslation(message.getContent()));
+    }
+
+    /**
+     * 번역 결과를 저장한다. 트랜잭션을 짧게 쪼갠 뒤라, 동시 요청이 같은 (메시지, 언어)를 각각
+     * 번역해 저장하려 하면 유니크 제약(chat_message_id, target_language)에 걸릴 수 있다.
+     * 그 경합은 호출자({@link ChatTranslationService})가 잡아 먼저 저장된 결과로 대체하므로,
+     * 여기서는 커밋 지연 없이 제약 위반이 즉시 드러나도록 {@code saveAndFlush}로 강제 flush 한다.
+     */
+    @Transactional
+    ChatTranslationResponse save(UUID messageId, String targetLanguage, TranslationResult result) {
+        ChatMessage message = chatMessageRepository.getReferenceById(messageId);
+        ChatMessageTranslation saved = translationRepository.saveAndFlush(ChatMessageTranslation.builder()
+                .chatMessage(message)
+                .targetLanguage(targetLanguage)
+                .translatedText(result.translatedText())
+                .providerName(result.providerName())
+                .modelVersion(result.modelVersion())
+                .build());
+        return toResponse(saved, false);
+    }
+
+    /**
+     * 이미 저장된 번역을 캐시로 조회한다. 저장 경합(동시 요청)에서 진 쪽이 승자의 결과를
+     * 돌려주기 위해 새 트랜잭션에서 다시 읽을 때 사용한다.
+     */
+    @Transactional(readOnly = true)
+    ChatTranslationResponse getCached(UUID messageId, String targetLanguage) {
+        return translationRepository.findByChatMessageIdAndTargetLanguage(messageId, targetLanguage)
+                .map(cached -> toResponse(cached, true))
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_ERROR, "번역 결과를 받지 못했습니다."));
+    }
+
+    private void requireTextMessage(ChatMessage message) {
+        if (message.getMessageType() != ChatMessageType.TEXT) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "텍스트 메시지만 번역할 수 있습니다");
+        }
+    }
+
+    private ChatTranslationResponse toResponse(ChatMessageTranslation translation, boolean cached) {
+        return new ChatTranslationResponse(
+                translation.getChatMessage().getId(),
+                translation.getTargetLanguage(),
+                translation.getTranslatedText(),
+                cached,
+                translation.getTranslatedAt());
+    }
+
+    /**
+     * {@link #lookup} 결과. 캐시 히트면 {@code cachedResponse}가, 미스면 번역할 {@code sourceText}가 채워진다.
+     */
+    record TranslationLookup(ChatTranslationResponse cachedResponse, String sourceText) {
+
+        static TranslationLookup cached(ChatTranslationResponse response) {
+            return new TranslationLookup(response, null);
+        }
+
+        static TranslationLookup needsTranslation(String sourceText) {
+            return new TranslationLookup(null, sourceText);
+        }
+
+        boolean isCached() {
+            return cachedResponse != null;
+        }
+    }
+}


### PR DESCRIPTION
## 배경

`ChatTranslationService`가 클래스 레벨 `@Transactional`이라, `translate()` 전 구간(외부 번역 API 호출 포함)이 하나의 DB 트랜잭션에서 돌았음. DeepL/Gemini 응답을 기다리는 내내 DB 커넥션을 점유해, 번역 지연 시 Hikari 풀(기본 10)이 고갈되고 로그인·채팅 등 무관한 요청까지 막히는 구조였음.

측정 근거와 상세는 #128 참고.

## 변경

외부 API 호출을 트랜잭션 **밖**으로 분리함.

- **`ChatTranslationStore` (신규)** — DB 작업만 담당하는 빈. `@Transactional` 프록시가 실제로 적용되도록 오케스트레이터와 분리(self-invocation 우회 방지).
  - `lookup(readOnly)` — 권한 검증 + 캐시 조회를 한 짧은 읽기 트랜잭션에서 끝냄. lazy 로딩 값은 트랜잭션 안에서 전부 추출(`open-in-view:false` 대응).
  - `save` — 결과 저장. `saveAndFlush`로 유니크 제약 위반을 즉시 감지.
  - `getCached(readOnly)` — 저장 경합 시 승자 결과 재조회(새 트랜잭션).
- **`ChatTranslationService`** — 트랜잭션 없는 오케스트레이터로 변경. `lookup → (트랜잭션 밖) 외부 호출 → save` 순으로 조율.
- 트랜잭션을 쪼갠 부작용인 동시 캐시미스 경합(유니크 제약 위반)은 `DataIntegrityViolationException`을 잡아 승자 결과로 대체.

## 효과 (재현 측정)

| 외부 API 시간 | Before 무관한 요청 p50 | After |
|---|---|---|
| 1500ms | 4,455ms (50/50 예산 초과) | ~1ms |
| 10s (DeepL 다운) | 무관한 요청 100% 실패 | 실패 0 |

## 테스트

- 기존 `ChatTranslationServiceTest` 5개 통과 (동작 계약 유지).

## 남은 작업 (후속)

- DeepL read-timeout(10s) 단축 + Circuit Breaker로 죽은 provider 빠른 우회 (별도 이슈 예정).

Closes #128
