### PR TITLE
FIX: FailoverTranslationProvider 생성자 모호성으로 앱 기동 실패 해결

### DIFF
--- a/src/main/java/com/deoham/chat/translation/FailoverTranslationProvider.java
+++ b/src/main/java/com/deoham/chat/translation/FailoverTranslationProvider.java
@@ -6,6 +6,7 @@ import com.deoham.global.exception.ErrorCode;
 import java.time.Clock;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,8 @@ public class FailoverTranslationProvider implements TranslationProvider {
     private final GeminiTranslationProvider fallback;
     private final SimpleCircuitBreaker deeplBreaker;
 
+    // 생성자가 둘이라 Spring이 스스로 고르지 못한다. 운영에서 쓸 생성자를 명시한다.
+    @Autowired
     public FailoverTranslationProvider(DeepLTranslationProvider primary, GeminiTranslationProvider fallback) {
         this(primary, fallback, new SimpleCircuitBreaker(FAILURE_THRESHOLD, OPEN_DURATION, Clock.systemUTC()));
     }

--- a/src/test/java/com/deoham/chat/translation/FailoverTranslationProviderWiringTest.java
+++ b/src/test/java/com/deoham/chat/translation/FailoverTranslationProviderWiringTest.java
@@ -1,0 +1,39 @@
+package com.deoham.chat.translation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * {@link FailoverTranslationProvider}는 {@code @Profile("!test")}라 어떤 컨텍스트 테스트에서도 생성되지 않는다.
+ * 그래서 생성자를 하나 더 추가해 Spring이 주입 대상을 고르지 못하게 되어도 테스트는 전부 통과하고,
+ * 운영 기동 시점에야 {@code NoSuchMethodException: <init>()}으로 터진다(실제 배포 장애 발생).
+ *
+ * <p>이 테스트는 그 구멍을 막는다 — 실제 Spring 생성자 선택 로직에 클래스를 그대로 태워본다.
+ */
+class FailoverTranslationProviderWiringTest {
+
+    @Test
+    @DisplayName("Spring이 주입 생성자를 스스로 선택해 빈을 생성할 수 있다")
+    void springCanInstantiateBean() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        AutowiredAnnotationBeanPostProcessor processor = new AutowiredAnnotationBeanPostProcessor();
+        processor.setBeanFactory(beanFactory);
+        beanFactory.addBeanPostProcessor(processor);
+
+        beanFactory.registerSingleton("deepLTranslationProvider", mock(DeepLTranslationProvider.class));
+        beanFactory.registerSingleton("geminiTranslationProvider", mock(GeminiTranslationProvider.class));
+        beanFactory.registerBeanDefinition(
+                "failoverTranslationProvider", new RootBeanDefinition(FailoverTranslationProvider.class));
+
+        assertThatCode(() -> beanFactory.getBean("failoverTranslationProvider")).doesNotThrowAnyException();
+        assertThat(beanFactory.getBean("failoverTranslationProvider"))
+                .isInstanceOf(FailoverTranslationProvider.class);
+    }
+}


### PR DESCRIPTION
## 문제

`develop` 배포가 실패하고 있었습니다 — 앱 컨테이너가 unhealthy 로 떨어져 `docker compose up` 이 중단됨.

```
dependency failed to start: container deoham-app-1 is unhealthy
```

## 원인

#131(서킷 브레이커)에서 테스트용 생성자를 추가하며 `FailoverTranslationProvider` 의 생성자가 2개가 되었습니다.
`@Autowired` 표시가 없으면 Spring 은 주입 생성자를 스스로 고르지 못하고 기본 생성자를 찾다가 실패합니다:

```
NoSuchMethodException: com.deoham.chat.translation.FailoverTranslationProvider.<init>()
```

**CI 가 이걸 못 잡은 이유**: 이 빈은 `@Profile("!test")` 라서 테스트 컨텍스트에서 아예 생성되지 않습니다.
빌드는 계속 초록이었고, 운영 기동 시점에만 터졌습니다.

## 수정

- 운영에서 사용할 생성자에 `@Autowired` 명시
- 실제 Spring 생성자 선택 로직에 클래스를 태우는 회귀 테스트 추가 (`FailoverTranslationProviderWiringTest`) — `@Profile` 때문에 컨텍스트 테스트가 못 덮는 구간을 메웁니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHcA33Npqf4DRqY8pK1oTS