### PR TITLE
FIX: @Async private 메서드 무효화로 S3 삭제가 트랜잭션 내 동기 실행되던 문제

### DIFF
--- a/src/main/java/com/deoham/global/config/AsyncConfig.java
+++ b/src/main/java/com/deoham/global/config/AsyncConfig.java
@@ -24,4 +24,18 @@ public class AsyncConfig {
 		executor.initialize();
 		return executor;
 	}
+
+	/**
+	 * S3 객체 삭제 전용 풀. FCM 풀과 분리해 S3 지연이 푸시 발송을 굶기지 않도록 한다.
+	 */
+	@Bean(name = "s3TaskExecutor")
+	public Executor s3TaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(2);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("s3-");
+		executor.initialize();
+		return executor;
+	}
 }

--- a/src/main/java/com/deoham/user/event/ProfileImageDeletedEvent.java
+++ b/src/main/java/com/deoham/user/event/ProfileImageDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.deoham.user.event;
+
+/**
+ * 커밋 후 S3 프로필 이미지 삭제를 위한 도메인 이벤트.
+ *
+ * <p>엔티티가 아니라 URL 문자열만 담아 트랜잭션 커밋 이후(다른 스레드)에도 detached/lazy 로딩 문제가 없도록 한다.
+ */
+public record ProfileImageDeletedEvent(String imageUrl) {
+}

--- a/src/main/java/com/deoham/user/event/ProfileImageDeletionListener.java
+++ b/src/main/java/com/deoham/user/event/ProfileImageDeletionListener.java
@@ -1,0 +1,60 @@
+package com.deoham.user.event;
+
+import com.deoham.global.config.S3Properties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * S3 프로필 이미지 실제 삭제기.
+ *
+ * <p>비즈니스 트랜잭션이 <b>커밋된 이후</b>({@link TransactionPhase#AFTER_COMMIT}) 별도 스레드에서 실행된다.
+ * 커밋 전에 지우면 이후 롤백 시 DB에는 URL이 남고 실물 파일만 사라져 복구가 불가능하므로 커밋 이후로 미루고,
+ * S3 네트워크 왕복이 DB 커넥션을 점유하지 않도록 전용 스레드 풀에서 처리한다.
+ * 삭제 실패는 예외를 전파하지 않고 로깅만 한다(이미지 정리는 부가 작업이므로 본 흐름에 영향 주지 않음).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProfileImageDeletionListener {
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    /**
+     * {@code fallbackExecution = true}는 트랜잭션 없이 발행된 경우에도 삭제가 유실되지 않도록 하는 방어책이다.
+     * (현재 호출 경로는 모두 트랜잭션 안이므로 평상시에는 AFTER_COMMIT으로만 동작한다.)
+     */
+    @Async("s3TaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void handle(ProfileImageDeletedEvent event) {
+        String imageUrl = event.imageUrl();
+        String key = extractS3Key(imageUrl);
+        if (key == null || key.isBlank()) {
+            log.warn("S3 키 추출 실패 - 프로필 이미지 삭제 스킵 [url={}]", imageUrl);
+            return;
+        }
+
+        try {
+            s3Client.deleteObject(builder -> builder
+                    .bucket(s3Properties.bucket())
+                    .key(key)
+                    .build());
+            log.debug("프로필 이미지 삭제 완료 [bucket={}, key={}]", s3Properties.bucket(), key);
+        } catch (Exception exception) {
+            log.error("프로필 이미지 삭제 실패 [bucket={}, key={}]", s3Properties.bucket(), key, exception);
+        }
+    }
+
+    private String extractS3Key(String imageUrl) {
+        String prefix = "https://" + s3Properties.bucket() + ".s3." + s3Properties.region() + ".amazonaws.com/";
+        if (imageUrl != null && imageUrl.startsWith(prefix)) {
+            return imageUrl.substring(prefix.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
+++ b/src/main/java/com/deoham/user/service/impl/UserWriteServiceImpl.java
@@ -12,6 +12,7 @@ import com.deoham.notification.repository.FcmTokenRepository;
 import com.deoham.notification.repository.NotificationRepository;
 import com.deoham.user.entity.User;
 import com.deoham.user.entity.UserStatus;
+import com.deoham.user.event.ProfileImageDeletedEvent;
 import com.deoham.user.repository.UserRepository;
 import com.deoham.user.repository.UserSocialAccountRepository;
 import com.deoham.user.service.UserWriteService;
@@ -21,7 +22,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,6 +47,7 @@ public class UserWriteServiceImpl implements UserWriteService {
 	private final MetricsRegistry metricsRegistry;
 	private final S3Client s3Client;
 	private final S3Properties s3Properties;
+	private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public User updateProfile(UUID userId, String nickname, MultipartFile profileImage) {
@@ -151,6 +153,11 @@ public class UserWriteServiceImpl implements UserWriteService {
 		deleteProfileImage(user);
 	}
 
+	/**
+	 * S3 삭제는 직접 호출하지 않고 이벤트로 위임한다.
+	 * 커밋 전에 지우면 이후 롤백 시 DB에는 URL이 남고 실물 파일만 사라지므로,
+	 * {@link com.deoham.user.event.ProfileImageDeletionListener}가 커밋 이후 별도 스레드에서 처리한다.
+	 */
 	private void deleteProfileImage(User user) {
 		String profileImageUrl = user.getProfileImageUrl();
 
@@ -158,46 +165,8 @@ public class UserWriteServiceImpl implements UserWriteService {
 		userRepository.save(user);
 
 		if (profileImageUrl != null && !profileImageUrl.isBlank()) {
-			deleteProfileImageAsync(profileImageUrl);
+			eventPublisher.publishEvent(new ProfileImageDeletedEvent(profileImageUrl));
 		}
-	}
-
-	@Async
-	private void deleteProfileImageAsync(String imageUrl) {
-		try {
-			deleteProfileImageFromS3(imageUrl);
-		} catch (Exception e) {
-			log.error("Failed to delete S3 image asynchronously: {}", imageUrl, e);
-		}
-	}
-
-	private void deleteProfileImageFromS3(String imageUrl) {
-		String key = extractS3KeyFromUrl(imageUrl);
-
-		if (key == null || key.isBlank()) {
-			log.warn("Failed to extract S3 key from URL: {}", imageUrl);
-			throw new BusinessException(ErrorCode.INTERNAL_ERROR,
-				"Invalid S3 image URL format: " + imageUrl);
-		}
-
-		s3Client.deleteObject(builder -> builder
-			.bucket(s3Properties.bucket())
-			.key(key)
-			.build());
-
-		log.debug("Deleted S3 object: {}/{}", s3Properties.bucket(), key);
-	}
-
-	private String extractS3KeyFromUrl(String imageUrl) {
-		String prefix = buildS3UrlPrefix();
-		if (imageUrl != null && imageUrl.startsWith(prefix)) {
-			return imageUrl.substring(prefix.length());
-		}
-		return null;
-	}
-
-	private String buildS3UrlPrefix() {
-		return "https://" + s3Properties.bucket() + ".s3." + s3Properties.region() + ".amazonaws.com/";
 	}
 
 	public void deleteExpiredDeletedUsers() {

--- a/src/test/java/com/deoham/user/service/ProfileImageDeletionEventTest.java
+++ b/src/test/java/com/deoham/user/service/ProfileImageDeletionEventTest.java
@@ -1,0 +1,160 @@
+package com.deoham.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.deoham.card.repository.CardApplyRepository;
+import com.deoham.card.repository.CardRepository;
+import com.deoham.global.config.S3Properties;
+import com.deoham.global.metrics.MetricsRegistry;
+import com.deoham.notification.repository.FcmTokenRepository;
+import com.deoham.notification.repository.NotificationRepository;
+import com.deoham.user.entity.User;
+import com.deoham.user.event.ProfileImageDeletedEvent;
+import com.deoham.user.event.ProfileImageDeletionListener;
+import com.deoham.user.repository.UserRepository;
+import com.deoham.user.repository.UserSocialAccountRepository;
+import com.deoham.user.service.impl.UserWriteServiceImpl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+/**
+ * 프로필 이미지 삭제가 S3를 직접 호출하지 않고 이벤트로 위임되는지 검증한다.
+ * 이전 구현은 private 메서드에 붙은 {@code @Async}가 프록시를 타지 않아 트랜잭션 안에서 동기로 S3를 호출했다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("프로필 이미지 삭제 이벤트 테스트")
+class ProfileImageDeletionEventTest {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String REGION = "ap-northeast-2";
+    private static final String KEY = "profiles/abc/image.png";
+    private static final String IMAGE_URL =
+            "https://" + BUCKET + ".s3." + REGION + ".amazonaws.com/" + KEY;
+
+    @Mock private UserRepository userRepository;
+    @Mock private CardRepository cardRepository;
+    @Mock private CardApplyRepository cardApplyRepository;
+    @Mock private UserSocialAccountRepository userSocialAccountRepository;
+    @Mock private FcmTokenRepository fcmTokenRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private S3Client s3Client;
+    @Mock private S3Properties s3Properties;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private UserWriteServiceImpl userWriteService;
+    private ProfileImageDeletionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        when(s3Properties.bucket()).thenReturn(BUCKET);
+        when(s3Properties.region()).thenReturn(REGION);
+        userWriteService = new UserWriteServiceImpl(
+                userRepository,
+                cardRepository,
+                cardApplyRepository,
+                userSocialAccountRepository,
+                fcmTokenRepository,
+                notificationRepository,
+                new MetricsRegistry(new SimpleMeterRegistry()),
+                s3Client,
+                s3Properties,
+                eventPublisher);
+        listener = new ProfileImageDeletionListener(s3Client, s3Properties);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 시 S3를 직접 호출하지 않고 이벤트만 발행한다")
+    void deleteProfileImage_publishesEventWithoutTouchingS3() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        User user = User.builder().firebaseUid("uid").nickname("tester").build();
+        user.updateProfile(null, IMAGE_URL);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        userWriteService.deleteProfileImage(userId);
+
+        // Then — 트랜잭션 안에서는 S3를 건드리지 않는다 (롤백 시 파일 유실 방지)
+        verifyNoInteractions(s3Client);
+        ArgumentCaptor<ProfileImageDeletedEvent> captor =
+                ArgumentCaptor.forClass(ProfileImageDeletedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().imageUrl()).isEqualTo(IMAGE_URL);
+        assertThat(user.getProfileImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("이미지가 없으면 이벤트를 발행하지 않는다")
+    void deleteProfileImage_noImage_publishesNothing() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        User user = User.builder().firebaseUid("uid").nickname("tester").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        userWriteService.deleteProfileImage(userId);
+
+        // Then
+        verify(eventPublisher, never()).publishEvent(any(ProfileImageDeletedEvent.class));
+    }
+
+    @Test
+    @DisplayName("리스너가 URL에서 키를 추출해 S3 객체를 삭제한다")
+    void listener_deletesS3Object() {
+        // When
+        listener.handle(new ProfileImageDeletedEvent(IMAGE_URL));
+
+        // Then
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<DeleteObjectRequest.Builder>> captor =
+                ArgumentCaptor.forClass(Consumer.class);
+        verify(s3Client).deleteObject(captor.capture());
+
+        DeleteObjectRequest.Builder builder = DeleteObjectRequest.builder();
+        captor.getValue().accept(builder);
+        DeleteObjectRequest request = builder.build();
+        assertThat(request.bucket()).isEqualTo(BUCKET);
+        assertThat(request.key()).isEqualTo(KEY);
+    }
+
+    @Test
+    @DisplayName("버킷 URL 형식이 아니면 삭제를 시도하지 않는다")
+    void listener_skipsUnknownUrl() {
+        // When
+        listener.handle(new ProfileImageDeletedEvent("https://other-host.example.com/x.png"));
+
+        // Then
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    @DisplayName("S3 삭제가 실패해도 예외를 전파하지 않는다")
+    void listener_swallowsFailure() {
+        // Given
+        when(s3Client.deleteObject(any(Consumer.class)))
+                .thenThrow(new RuntimeException("S3 down"));
+
+        // When & Then — 부가 작업이므로 본 흐름에 영향을 주지 않는다
+        listener.handle(new ProfileImageDeletedEvent(IMAGE_URL));
+    }
+}

--- a/src/test/java/com/deoham/user/service/UserServiceMetricsTest.java
+++ b/src/test/java/com/deoham/user/service/UserServiceMetricsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.Optional;
@@ -47,6 +48,7 @@ class UserServiceMetricsTest {
   @Mock private NotificationRepository notificationRepository;
   @Mock private S3Client s3Client;
   @Mock private S3Properties s3Properties;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @BeforeEach
   void setUp() {
@@ -63,7 +65,8 @@ class UserServiceMetricsTest {
             notificationRepository,
             metricsRegistry,
             s3Client,
-            s3Properties);
+            s3Properties,
+            eventPublisher);
   }
 
   @Test


### PR DESCRIPTION
## 🚀 관련 이슈

- close #135

## 🔑 주요 변경사항

`UserWriteServiceImpl.deleteProfileImageAsync()`의 `@Async`가 동작하지 않고 있었습니다. `private` 메서드이면서 같은 클래스 내부에서 직접 호출(self-invocation)돼 Spring AOP 프록시를 거치지 않기 때문입니다. 두 조건 각각만으로도 어드바이스가 적용되지 않으며, 예외도 경고도 없이 조용히 동기 실행됩니다.

이 클래스는 클래스 레벨 `@Transactional`이므로, 결과적으로 S3 `DeleteObject`가 **DB 트랜잭션 안에서 동기로** 실행되고 있었습니다.

1. **커넥션 점유** — S3 네트워크 왕복 시간만큼 DB 커넥션을 잡고 있습니다. #128(번역 API를 `@Transactional`이 감싸 커넥션 풀 고갈)과 같은 구조입니다.
2. **롤백 시 데이터 유실** — 커밋 전에 파일을 지우므로, 이후 롤백되면 DB에는 `profile_image_url`이 남고 실물만 사라집니다. 복구 불가입니다.

### 해결 — FCM 발송과 동일한 패턴으로 전환

| 파일 | 변경 |
|---|---|
| `user/event/ProfileImageDeletedEvent.java` | 신규. URL 문자열만 담은 record |
| `user/event/ProfileImageDeletionListener.java` | 신규. `@TransactionalEventListener(AFTER_COMMIT)` + `@Async("s3TaskExecutor")` |
| `user/service/impl/UserWriteServiceImpl.java` | S3 삭제 로직 제거 → 이벤트 발행으로 대체 (`@Async` private 메서드 + 헬퍼 3개 삭제) |
| `global/config/AsyncConfig.java` | `s3TaskExecutor` 추가 (core 1 / max 2 / queue 100) |

`FcmPushEvent` + `FcmSender`가 이미 검증한 구조를 그대로 따랐습니다. 커밋 이후에만 실행되므로 롤백 시 S3 객체가 보존되고, 별도 스레드 풀에서 실행되므로 DB 커넥션을 점유하지 않습니다. 삭제 실패는 예외를 전파하지 않고 로깅만 합니다(이미지 정리는 부가 작업이므로 본 흐름에 영향 주지 않음).

### 판단이 필요했던 지점

**1. 스레드 풀을 재사용하지 않고 `s3TaskExecutor`를 신설했습니다**

`fcmTaskExecutor`를 재사용하면 S3 지연이 푸시 발송을 굶길 수 있습니다(head-of-line blocking). 알림 지연이 사용자에게 더 민감하다고 판단해 풀을 분리했습니다. 삭제는 처리량이 낮은 작업이라 core 1 / max 2로 잡았습니다.

**2. 리스너에 `@Transactional`을 붙이지 않았습니다**

`FcmSender`는 커밋 이후 별도 스레드에서 FCM 토큰을 조회해야 해서 `REQUIRES_NEW`가 필요했지만, 이 리스너는 DB 접근이 없습니다. 불필요한 트랜잭션을 열지 않았습니다.

**3. `fallbackExecution = true`를 지정했습니다**

`@TransactionalEventListener`는 트랜잭션 없이 발행되면 기본적으로 **이벤트를 조용히 버립니다.** 현재 호출 경로(`deleteUser`, `deleteProfileImage`)는 모두 클래스 레벨 `@Transactional` 안이라 평상시에는 `AFTER_COMMIT`으로만 동작하지만, 향후 트랜잭션 밖에서 호출되는 경로가 생겼을 때 이미지가 영구히 방치되는 것을 막기 위한 방어책입니다.

**4. `deleteUser()`의 `try/catch`는 그대로 뒀습니다**

이제 감싸는 대상이 `save` + 이벤트 발행이라 실질적으로 S3 예외를 잡지는 않지만, 제거하면 이번 변경의 범위를 넘어섭니다. 동작상 해가 없어 유지했습니다.

### 테스트

`ProfileImageDeletionEventTest` 5건 신규:

| 검증 | 내용 |
|---|---|
| `deleteProfileImage_publishesEventWithoutTouchingS3` | `verifyNoInteractions(s3Client)` — 트랜잭션 안에서 S3를 건드리지 않음을 증명. 회귀 시 이 단정이 깨집니다 |
| `deleteProfileImage_noImage_publishesNothing` | 이미지가 없으면 이벤트를 발행하지 않음 |
| `listener_deletesS3Object` | `Consumer<DeleteObjectRequest.Builder>`를 캡처해 실제로 조립되는 bucket/key를 검증 |
| `listener_skipsUnknownUrl` | 버킷 URL 형식이 아니면 삭제를 시도하지 않음 |
| `listener_swallowsFailure` | S3 예외가 전파되지 않음 |

`UserServiceMetricsTest`는 생성자 인자(`ApplicationEventPublisher`) 추가로 수정했습니다.

### 검증 — 실행한 것과 못 돌린 것

**로컬에 Docker가 없어 Testcontainers 기반 테스트는 실행하지 못했습니다.** (#134와 동일한 상황입니다)

- ✅ `./gradlew compileJava compileTestJava` — 통과
- ✅ `./gradlew test --tests 'com.deoham.user.service.*'` — 11건 통과 (`ProfileImageDeletionEventTest` 5, `UserServiceMetricsTest` 6)
- ❌ `./gradlew test` — `198 tests completed, 64 failed`
  - 64건 **전부** `IllegalStateException`(Spring ApplicationContext 로드 실패)이고 근본 원인은 `Could not find a valid Docker environment`입니다. **단정 실패(assertion failure)는 0건입니다.**
  - 실패 클래스 8개(`DeohamApplicationTests`, `AuthServiceKakaoFailureTest`, `ChatConcurrencyTest`, `ChatMessageServiceTest`, `ChatRoomServiceTest`, `ChatTranslationServiceTest`, `NotificationServiceTest`, `ReportServiceTest`)는 모두 `TestcontainersConfiguration`을 `@Import` 하는 클래스이며, #134에서 보고된 것과 동일한 목록입니다. 즉 이 PR로 새로 깨진 테스트는 없습니다.
  - 다만 이 PR이 건드린 `UserWriteServiceImpl`을 스프링 컨텍스트에서 사용하는 통합 테스트는 **CI에서 확인이 필요합니다.**

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지) — base는 `develop`입니다
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가? — 삭제 실패는 리스너에서 catch 후 로깅만 하고 전파하지 않습니다. 기존 `BusinessException(INTERNAL_ERROR)` throw는 제거했습니다(비동기 스레드에서 던져봐야 호출자에게 도달하지 않고, 이미지 정리 실패가 회원 탈퇴/프로필 수정을 실패시켜서는 안 되기 때문입니다)
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? — 성공 `debug`, 키 추출 실패 `warn`, 삭제 실패 `error`. 모두 bucket/key를 포함합니다
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가? — 위 "검증" 항목 참고. Docker 부재로 Testcontainers 테스트 64건을 돌리지 못했습니다

## ↗️ 개선 사항

**후속 이슈로 분리가 필요한 항목 (이번 범위 밖)**

- **`UserWriteServiceImpl.permanentlyDeleteUser()`도 같은 버그입니다.** `private` + self-invocation이라 `@Transactional`이 적용되지 않습니다. 이 경우 `deleteExpiredDeletedUsers()`의 사용자별 `try/catch`가 실패를 격리하지 못하고, 호출자 트랜잭션이 rollback-only로 마킹돼 전체가 함께 롤백될 수 있습니다. 트랜잭션 경계를 바꿔야 해서 영향 범위가 달라 이번 PR에 넣지 않았습니다.
- **`ChatMessageService`의 커밋 전 브로드캐스트** — `messagingTemplate.convertAndSend()`가 `@Transactional` 안에 있습니다(채팅방 종료 안내, 읽음 처리). 커밋 전에 STOMP로 나가므로 롤백되면 클라이언트만 존재하지 않는 메시지·읽음 상태를 갖게 됩니다. 이번 PR과 정확히 같은 성격의 문제입니다.
- **도메인 간 직접 의존** — `DefaultCardWriteService`, `ChatMessageService`가 `NotificationService`를 직접 호출합니다. 이벤트로 대체하면 알림 채널 확장 시 발행 측을 수정할 필요가 없어집니다.

**이번에 손대지 않고 지적만 남기는 항목**

- **`s3TaskExecutor` 풀 크기(core 1 / max 2)는 잠정값입니다.** 프로필 이미지 삭제 빈도에 대한 실측 데이터가 없어 보수적으로 잡았습니다. 회원 탈퇴가 몰리는 시점에 queue(100)가 차면 `AbortPolicy` 기본값에 따라 `RejectedExecutionException`이 발생하고 해당 이미지는 방치됩니다. 운영 지표를 보고 조정이 필요합니다.
- **삭제 실패 시 재시도가 없습니다.** 로깅만 하므로 S3 장애 중 삭제 요청은 유실되고 고아 객체가 남습니다. 정합성이 중요해지면 S3 라이프사이클 정책이나 별도 정리 배치를 검토해야 합니다.
- **`extractS3Key`가 `UserWriteServiceImpl`의 업로드 URL 조립 로직과 규칙을 중복 보유합니다.** 업로드는 서비스에, 삭제는 리스너에 있어 URL 형식이 두 곳에 하드코딩돼 있습니다. 버킷/리전 표기 방식이 바뀌면 양쪽을 함께 고쳐야 합니다. 공통 유틸로 뽑는 것이 자연스러워 보이나 이번 범위를 넘어 두었습니다.

## 📔 참고 자료

- 이슈 #135 — `@Async` 무효화 조건과 영향 분석
- 유사 구조의 선행 사례: #128 (외부 API 호출이 트랜잭션에 포함돼 커넥션 풀 고갈)
- 참고한 기존 패턴: `notification/event/FcmPushEvent` + `notification/service/FcmSender`
